### PR TITLE
Add CLJ-Kondo linter to Triangulum

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:linters {:missing-docstring {:level :warning}}}

--- a/.github/workflows/clj-kondo.yml
+++ b/.github/workflows/clj-kondo.yml
@@ -1,0 +1,15 @@
+name: clj-kondo linter
+
+on: [push, pull_request]
+
+jobs:
+  clj-lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DeLaGuardo/clojure-lint-action@master
+      with:
+        clj-kondo-args: --lint src test
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .cpcache/
 .nrepl-port
+.rebel_readline_history
+.clj-kondo/*
+!.clj-kondo/config.edn
+
 pom.xml
 target/
-.clj-kondo/.cache/**

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .nrepl-port
 pom.xml
 target/
+.clj-kondo/.cache/**


### PR DESCRIPTION
### Purpose
Add Clojure linting for all pull-requests and branch pushes to catch errors early

### Steps
1. Added `.clj-kondo/config.edn`
2. Add github workflow (`.github/workflows/clj-kondo.yml`) to check `src` and `test` directories
