### PR TITLE
TRI-46 Only run CI Jobs on Pull Requests

### DIFF
--- a/.github/workflows/clj-kondo.yml
+++ b/.github/workflows/clj-kondo.yml
@@ -1,6 +1,9 @@
 name: clj-kondo linter
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   clj-lint:

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,6 +1,9 @@
 name: Clojure CI
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Only run CI jobs on pull requests against `main`

## Related Issues
Closes TRI-46
