### PR TITLE
TRI-60 Pass database variable to SQL

### DIFF
--- a/README.org
+++ b/README.org
@@ -114,19 +114,18 @@ the database server's superuser account is named "postgres" and that
 you know its database connection password before proceeding.
 
 Once the Postgresql database server is running on your machine, you
-should navigate to the toplevel directory (i.e., the directory
+should navigate to the top level directory (i.e., the directory
 containing this README) and run the database build command as follows:
 
 #+begin_src sh
-clojure -M:build-db build-all
+clojure -M:build-db build-all -d database [-u user] [-p admin password]
 #+end_src
 
-This will begin by creating a new database and role called ceo and
-then add the postgis and pgcrypto extensions to it. Next, the script
-will populate the database with the schemas, tables, and functions
-that are necessary for storing and processing ceo's data. Finally, it
-will load some default data into these tables that is necessary for
-the website to function properly.
+This will call ./src/sql/create_db.sql, stored in the individual project
+repository.  A variable ~database~ is set for the command line call to
+create_db.sql.  This allows your project to generate the project database
+with a different name, depending on your deployment.  To use this variable
+type ~:database~ in create_db.sql where needed.
 
 *** triangulum.https
 
@@ -172,7 +171,7 @@ format.
 Add alias to ~deps.edn~.
 
 #+begin_src clojure
-{:aliases {:build-db {:main-opts ["-m" "triangulum.build-db" "-d" "MYDB"]}
+{:aliases {:build-db {:main-opts ["-m" "triangulum.build-db"]}
            :https    {:main-opts ["-m" "triangulum.https"]}}}
 #+end_src
 

--- a/src/triangulum/build_db.clj
+++ b/src/triangulum/build_db.clj
@@ -98,7 +98,7 @@
 
 (defn- load-functions [database user verbose]
   (println "Loading functions...")
-  (->> (map #(format-str "psql -h localhost -U %u -d %d -f %f" database user database %)
+  (->> (map #(format-str "psql -h localhost -U %u -d %d -f %f" user database %)
             (topo-sort-files-by-namespace "./src/sql/functions"))
        (apply sh-wrapper "./" {:PGPASSWORD user} verbose)
        (println)))
@@ -123,7 +123,7 @@
           (load-tables       database user verbose)
           (load-functions    database user verbose)
           (load-default-data database user verbose))
-      (println "Error folder ./src/sql/create_db.sql is missing."))))
+      (println "Error file ./src/sql/create_db.sql is missing."))))
 
 ;; Backup / restore functions
 

--- a/src/triangulum/build_db.clj
+++ b/src/triangulum/build_db.clj
@@ -98,7 +98,7 @@
 
 (defn- load-functions [database user verbose]
   (println "Loading functions...")
-  (->> (map #(format-str "psql -h localhost -U %u -d %d -f %f" user database %)
+  (->> (map #(format-str "psql -h localhost -U %u -d %d -f %f" database user database %)
             (topo-sort-files-by-namespace "./src/sql/functions"))
        (apply sh-wrapper "./" {:PGPASSWORD user} verbose)
        (println)))
@@ -112,17 +112,18 @@
 
 (defn- build-everything [database user password verbose]
   (println "Building database...")
-  (let [file (io/file "./src/sql")]
+  (let [file (io/file "./src/sql/create_db.sql")]
     (if (.exists file)
       (do (->> (sh-wrapper "./src/sql"
                            {:PGPASSWORD password}
                            verbose
-                           "psql -h localhost -U postgres -f create_db.sql")
+                           (format "psql -h localhost --set=database=%s -U postgres -f create_db.sql"
+                                   database))
                (println))
           (load-tables       database user verbose)
           (load-functions    database user verbose)
           (load-default-data database user verbose))
-      (println "Error folder ./src/sql is missing."))))
+      (println "Error folder ./src/sql/create_db.sql is missing."))))
 
 ;; Backup / restore functions
 


### PR DESCRIPTION
## Purpose
Pass database variable to SQL

## Related Issues
Closes TRI-60

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
1. When I use the -d database cli command, Then I am able to use the :database variable in my create_db.sql script.

