### PR TITLE
TRI-56 Add specs for config

### DIFF
--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -1,6 +1,23 @@
 (ns triangulum.config
-  (:require [clojure.java.io :as io]
-            [clojure.edn     :as edn]))
+  (:require [clojure.java.io    :as io]
+            [clojure.edn        :as edn]
+            [clojure.spec.alpha :as s]))
+
+;;; Specs
+
+(s/def ::host     string?)
+(s/def ::port     nat-int?)
+(s/def ::dbname   string?)
+(s/def ::user     string?)
+(s/def ::password string?)
+(s/def ::domain   string?)
+
+(s/def ::database (s/keys :req-un [::dbname ::user ::password]
+                           :opt-un [::host ::port]))
+(s/def ::http     (s/keys :req-un [::port]))
+(s/def ::ssl      (s/keys :req-un [::domain]))
+
+(s/def ::config (s/keys :opt-un [::database ::http ::ssl]))
 
 ;;; Private vars
 
@@ -10,10 +27,12 @@
 ;;; Helper Fns
 
 (defn- read-config []
-  (if (.exists (io/file config-file))
-    (edn/read-string (slurp config-file))
-    (do (println "Error: Cannot find file config.edn.")
-        {})))
+  (if-not (.exists (io/file config-file))
+    (println "Error: Cannot find file config.edn.")
+    (let [config (->> (slurp config-file) (edn/read-string) (s/conform ::config))]
+      (if (= :clojure.spec.alpha/invalid config)
+        (do (println "Error: Invalid config.edn file") (s/explain ::config config))
+        config))))
 
 (defn- cache-config []
   (or @config-cache

--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -13,7 +13,7 @@
 (s/def ::domain   string?)
 
 (s/def ::database (s/keys :req-un [::dbname ::user ::password]
-                           :opt-un [::host ::port]))
+                          :opt-un [::host ::port]))
 (s/def ::http     (s/keys :req-un [::port]))
 (s/def ::ssl      (s/keys :req-un [::domain]))
 
@@ -27,12 +27,14 @@
 ;;; Helper Fns
 
 (defn- read-config []
-  (if-not (.exists (io/file config-file))
-    (println "Error: Cannot find file config.edn.")
-    (let [config (->> (slurp config-file) (edn/read-string) (s/conform ::config))]
-      (if (= :clojure.spec.alpha/invalid config)
-        (do (println "Error: Invalid config.edn file") (s/explain ::config config))
-        config))))
+  (if (.exists (io/file config-file))
+    (let [config (->> (slurp config-file) (edn/read-string))]
+      (if (s/valid? ::config config)
+        config
+        (do
+          (println "Error: Invalid config.edn file")
+          (s/explain ::config config))))
+    (println "Error: Cannot find file config.edn.")))
 
 (defn- cache-config []
   (or @config-cache

--- a/src/triangulum/database.clj
+++ b/src/triangulum/database.clj
@@ -7,16 +7,6 @@
             [triangulum.logging   :refer [log-str]]
             [triangulum.utils     :refer [format-str]]))
 
-;;; Specs
-
-(s/def ::host string?)
-(s/def ::port nat-int?)
-(s/def ::dbname string?)
-(s/def ::user string?)
-(s/def ::password string?)
-(s/def ::db-config (s/keys :req-un [::dbname ::user ::password]
-                           :opt-un [::host ::port]))
-
 ;;; Helper Functions
 
 (defn- str-places
@@ -37,14 +27,11 @@
 ;;; Static Data
 
 (defn- pg-db []
-  (let [db-config (s/conform ::db-config (get-config :database))]
-    (if (= :clojure.spec.alpha/invalid db-config)
-      (throw (Exception. "config.edn is invalid. Error: " (s/explain ::db-config (get-config :database))))
-      (merge {:dbtype                "postgresql"
-              :host                  "localhost"
-              :port                  5432
-              :reWriteBatchedInserts true}
-             db-config))))
+  (merge {:dbtype                "postgresql"
+          :host                  "localhost"
+          :port                  5432
+          :reWriteBatchedInserts true}
+         (get-config :database)))
 
 ;;; Select Queries
 

--- a/src/triangulum/database.clj
+++ b/src/triangulum/database.clj
@@ -1,6 +1,5 @@
 (ns triangulum.database
   (:require [clojure.string       :as str]
-            [clojure.spec.alpha   :as s]
             [next.jdbc            :as jdbc]
             [next.jdbc.result-set :as rs]
             [triangulum.config    :refer [get-config]]
@@ -28,8 +27,6 @@
 
 (defn- pg-db []
   (merge {:dbtype                "postgresql"
-          :host                  "localhost"
-          :port                  5432
           :reWriteBatchedInserts true}
          (get-config :database)))
 

--- a/test/test_config.edn
+++ b/test/test_config.edn
@@ -1,2 +1,6 @@
 {:testing 1234
- :database {:host "localhost"}}
+ :database {:host     "localhost"
+            :port     5432
+            :dbname   "dbname"
+            :user     "user"
+            :password "password"}}

--- a/test/test_new_config.edn
+++ b/test/test_new_config.edn
@@ -1,2 +1,6 @@
 {:testing 4321
- :database {:host "production"}}
+ :database {:host     "production"
+            :port     5432
+            :dbname   "dbname"
+            :user     "user"
+            :password "password"}}


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds specs for `:database`, `:http`, and `:ssl` configurations. Checks that the entire `config.edn` file is valid before returning a config.

## Related Issues
Closes TRI-56

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
