### PR TITLE
TRI-57 Enable re/loading config file

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,9 @@
         org.clojure/tools.cli     {:mvn/version "1.0.206"}
         org.postgresql/postgresql {:mvn/version "42.2.10"}
         org.xerial/sqlite-jdbc    {:mvn/version "3.30.1"}
-        seancorfield/next.jdbc    {:mvn/version "1.1.613"}}
+        seancorfield/next.jdbc    {:mvn/version "1.1.613"}
+        seancorfield/depstar      {:mvn/version "2.0.165"}
+        deps-deploy/deps-deploy   {:mvn/version "0.0.12"}}
 
  :aliases {:build-db   {:main-opts ["-m" "triangulum.build-db"]}
            :https      {:main-opts ["-m" "triangulum.https"]}

--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -24,11 +24,10 @@
 (defn load-config
   "Re/loads a configuration file. Defaults to `config.edn`."
   ([]
-   (load-config config-file))
+   (load-config @config-file))
   ([new-config-file]
    (reset! config-file new-config-file)
-   (reset! config-cache nil)
-   (cache-config)))
+   (reset! config-cache nil)))
 
 (defn get-config
   "Retrieves the key `k` from the config file.

--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -4,28 +4,39 @@
 
 ;;; Private vars
 
-(def ^:private config-file "config.edn")
+(def ^:private config-file  (atom "config.edn"))
 (def ^:private config-cache (atom nil))
 
 ;;; Helper Fns
 
-(defn- read-config []
-  (if (.exists (io/file config-file))
-    (edn/read-string (slurp config-file))
+(defn- read-config [new-config-file]
+  (if (.exists (io/file new-config-file))
+    (edn/read-string (slurp new-config-file))
     (do (println "Error: Cannot find file config.edn.")
         {})))
 
 (defn- cache-config []
   (or @config-cache
-      (reset! config-cache (read-config))))
+      (reset! config-cache (read-config @config-file))))
 
 ;;; Public Fns
 
+(defn load-config
+  "Re/loads a configuration file. Defaults to `config.edn`."
+  ([]
+   (load-config config-file))
+  ([new-config-file]
+   (reset! config-file new-config-file)
+   (reset! config-cache nil)
+   (cache-config)))
+
 (defn get-config
-  "Retrieves the key `k` from the config.edn file.
+  "Retrieves the key `k` from the config file.
    Can also be called with the keys leading to a config.
    Examples:
-     (get-config :mail) -> {:host \"google.com\" :port 543}
-     (get-config :mail :host) -> \"google.com\""
+   ```clojure
+   (get-config :mail) -> {:host \"google.com\" :port 543}
+   (get-config :mail :host) -> \"google.com\"
+   ```"
   [& all-keys]
   (get-in (cache-config) all-keys))

--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -12,7 +12,7 @@
 (defn- read-config [new-config-file]
   (if (.exists (io/file new-config-file))
     (edn/read-string (slurp new-config-file))
-    (do (println "Error: Cannot find file config.edn.")
+    (do (println "Error: Cannot find file " new-config-file)
         {})))
 
 (defn- cache-config []
@@ -22,7 +22,7 @@
 ;;; Public Fns
 
 (defn load-config
-  "Re/loads a configuration file. Defaults to `config.edn`."
+  "Re/loads a configuration file. Defaults to the last loaded file, or config.edn."
   ([]
    (load-config @config-file))
   ([new-config-file]

--- a/test/test_config.edn
+++ b/test/test_config.edn
@@ -1,0 +1,2 @@
+{:testing 1234
+ :database {:host "localhost"}}

--- a/test/test_new_config.edn
+++ b/test/test_new_config.edn
@@ -1,0 +1,2 @@
+{:testing 4321
+ :database {:host "production"}}

--- a/test/triangulum/config_test.clj
+++ b/test/triangulum/config_test.clj
@@ -1,0 +1,25 @@
+(ns triangulum.config-test
+  (:require [clojure.test :refer [are is deftest testing use-fixtures]]
+            [triangulum.config :refer [get-config load-config]]))
+
+(defn- load-test-config [f]
+  (load-config "test/test_config.edn")
+  (f))
+
+(use-fixtures :once load-test-config)
+
+(deftest get-config-test
+  (testing "Get config for single value."
+    (is (= (get-config :testing)
+           1234)))
+  (testing "Get config for nested value."
+    (is (= (get-config :database :host)
+           "localhost"))))
+
+(deftest load-config-test
+  (testing "Load a different configuration."
+    (load-config "test/test_new_config.edn")
+    (is (= (get-config :testing)
+           4321))
+    (is (= (get-config :database :host)
+           "production"))))


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Enables reloading of the configuration file using `(config/load-config)`

## Related Issues
Closes TRI-57

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
