### PR TITLE
Add default p-insert-rows! fields arg

### DIFF
--- a/src/triangulum/database.clj
+++ b/src/triangulum/database.clj
@@ -97,9 +97,11 @@
 
 (defn p-insert-rows!
   "A parallel implementation of insert-rows!"
-  [table rows fields]
-  (doall (pmap (fn [row-group] (insert-rows! table row-group fields))
-               (pg-partition rows fields))))
+  ([table rows]
+   (p-insert-rows! table rows (keys (first rows))))
+  ([table rows fields]
+   (doall (pmap (fn [row-group] (insert-rows! table row-group fields))
+                (pg-partition rows fields)))))
 
 ;;; Update Queries
 

--- a/src/triangulum/database.clj
+++ b/src/triangulum/database.clj
@@ -135,6 +135,8 @@
 
 (defn p-update-rows!
   "A parallel implementation of update-rows!"
-  [table rows id-key fields]
-  (doall (pmap (fn [row-group] (update-rows! table row-group id-key fields))
-               (pg-partition rows fields))))
+  ([table rows id-key]
+   (p-update-rows! table rows id-key (keys (first rows))))
+  ([table rows id-key fields]
+   (doall (pmap (fn [row-group] (update-rows! table row-group id-key fields))
+                (pg-partition rows fields)))))


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds a 2-arity form of `p-insert-rows!` so which defaults `fields` to `(keys (first rows))`.

## Related Issues
Relates to CEO-211
