### PR TITLE
[WIP] TRI-7 Add apply-changes / reset-changes / last-change commands

### DIFF
--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -5,6 +5,12 @@
             [clojure.set       :as set]
             [clojure.data.json :as json]))
 
+(defmacro nil-on-error
+  "Uses try to catch and return nil on error"
+  [& body]
+  (let [_ (gensym)]
+    `(try ~@body (catch Exception ~_ nil))))
+
 ;; Text parsing
 
 (defn kebab->snake


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds the following CLI commands:
* `build-db apply-changes` - Applies the migration files under src/sql/changes in chronological order.
* `build-db reset-changes` - Resets the existing change file, which allows all migrations to be re-run.
* `build-db last-change` - Returns the last entry (in chronological order) from the change file.

## Related Issues
(Partially) Address TRI-7

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## TODOs
- [ ] Better error reporting for when a migration goes awry
- [ ] Possibly perform a backup before we migrate?
- [ ] Add `rollback` command