### PR TITLE
TRI-65 Add config validate cli command

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,6 +27,11 @@ To make organizing an application's configurations simpler, create a
 Add config.edn to your ~.gitignore~ file to keep sensitive information out of
 the git history.
 
+To validate the config.edn file, run:
+#+begin_src sh
+clojure -M:config validate [-f FILE]
+#+end_src
+
 To retrieve a configuration, use ~get-config~. You can supply nested
 configuration keys as follows:
 

--- a/deps.edn
+++ b/deps.edn
@@ -14,6 +14,7 @@
  :aliases {:build-db   {:main-opts ["-m" "triangulum.build-db"]}
            :https      {:main-opts ["-m" "triangulum.https"]}
            :systemd    {:main-opts ["-m" "triangulum.systemd"]}
+           :config     {:main-opts ["-m" "triangulum.config"]}
            :rebel      {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
                         :main-opts  ["-m" "rebel-readline.main"]}
            :check-deps {:extra-deps {olical/depot {:mvn/version "2.1.0"}}

--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -62,11 +62,10 @@
   [& all-keys]
   (get-in (cache-config) all-keys))
 
-(defn validate
-  "Validates `file` as a configuration file. Defaults to the "
+(defn valid-config?
+  "Validates `file` as a configuration file."
   [{:keys [file] :or {file @config-file}}]
-  (when (map? (read-config file))
-    (println "Valid config file:" file)))
+  (map? (read-config file)))
 
 (def ^:private cli-options
   {:validate ["-f" "--file FILE" "Configuration file to validate."]})
@@ -80,6 +79,6 @@
   [& args]
   (let [{:keys [action options]} (get-cli-options args cli-options cli-actions "config")]
     (case action
-      :validate (validate options)
+      :validate (valid-config? options)
       nil))
   (shutdown-agents))

--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -6,24 +6,19 @@
 
 ;;; Specs
 
-(s/def ::host       string?)
-(s/def ::port       (s/and nat-int? #(< % 0x10000)))
-(s/def ::https-port (s/and nat-int? #(< % 0x10000)))
-(s/def ::dbname     string?)
-(s/def ::user       string?)
-(s/def ::password   string?)
-(s/def ::domain     string?)
-(s/def ::mode       (s/and string? #{"prod" "dev"}))
-(s/def ::output-dir (s/and string? #(.isDirectory (io/file %))))
+(s/def ::host     string?)
+(s/def ::port     nat-int?)
+(s/def ::dbname   string?)
+(s/def ::user     string?)
+(s/def ::password string?)
+(s/def ::domain   string?)
 
 (s/def ::database (s/keys :req-un [::dbname ::user ::password]
                           :opt-un [::host ::port]))
 (s/def ::http     (s/keys :req-un [::port]))
 (s/def ::ssl      (s/keys :req-un [::domain]))
-(s/def ::server   (s/keys :req-un [::mode ::port]
-                          :opt-un [::https-port ::output-dir]))
 
-(s/def ::config (s/keys :opt-un [::database ::http ::ssl ::server]))
+(s/def ::config (s/keys :opt-un [::database ::http ::ssl]))
 
 ;;; Private vars
 
@@ -32,15 +27,15 @@
 
 ;;; Helper Fns
 
-(defn- read-config [new-config-file]
-  (if (.exists (io/file new-config-file))
-    (let [config (->> (slurp new-config-file) (edn/read-string))]
+(defn- read-config [file]
+  (if (.exists (io/file file))
+    (let [config (->> (slurp file) (edn/read-string))]
       (if (s/valid? ::config config)
         config
         (do
-          (println "Error: Invalid config.edn file")
+          (println "Invalid config file:" file)
           (s/explain ::config config))))
-    (println "Error: Cannot find file config.edn.")))
+    (println "Error: Cannot find file" file)))
 
 (defn- cache-config []
   (or @config-cache
@@ -70,14 +65,8 @@
 (defn validate
   "Validates `file` as a configuration file. Defaults to the "
   [{:keys [file] :or {file @config-file}}]
-  (if-not (.exists (io/file file))
-    (println "Unable to find config file: %s" file)
-    (let [config (->> (slurp file) (edn/read-string))]
-      (if (s/valid? ::config config)
-        (println (format "Config file %s is valid" file))
-        (do
-          (println (format "Invalid config file: %s" file))
-          (s/explain ::config config))))))
+  (when (map? (read-config file))
+    (println "Valid config file:" file)))
 
 (def ^:private cli-options
   {:validate ["-f" "--file FILE" "Configuration file to validate."]})


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds `clj -M:config validate [-f FILE]` command, which validates the file provided or the `config.edn` file by default.

## Related Issues
Closes TRI-65

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
