### PR TITLE
TRI-66 Add server config spec

### DIFF
--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -6,19 +6,24 @@
 
 ;;; Specs
 
-(s/def ::host     string?)
-(s/def ::port     nat-int?)
-(s/def ::dbname   string?)
-(s/def ::user     string?)
-(s/def ::password string?)
-(s/def ::domain   string?)
+(s/def ::host       string?)
+(s/def ::port       (s/and nat-int? #(< % 0x10000)))
+(s/def ::https-port (s/and nat-int? #(< % 0x10000)))
+(s/def ::dbname     string?)
+(s/def ::user       string?)
+(s/def ::password   string?)
+(s/def ::domain     string?)
+(s/def ::mode       (s/and string? #{"prod" "dev"}))
+(s/def ::output-dir (s/and string? #(.isDirectory (io/file %))))
 
 (s/def ::database (s/keys :req-un [::dbname ::user ::password]
                           :opt-un [::host ::port]))
 (s/def ::http     (s/keys :req-un [::port]))
 (s/def ::ssl      (s/keys :req-un [::domain]))
+(s/def ::server   (s/keys :req-un [::mode ::port]
+                          :opt-un [::https-port ::output-dir]))
 
-(s/def ::config (s/keys :opt-un [::database ::http ::ssl]))
+(s/def ::config (s/keys :opt-un [::database ::http ::ssl ::server]))
 
 ;;; Private vars
 


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds `:server` configuration specs. Example of a server configuration:

```clojure
;; config.edn
{:server {:port       8080
          :https-port 8443
          :mode       "prod"
          :output-dir "./logs"}}
```

## Related Issues
Closes TRI-66

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
