### PR TITLE
TRI-64 TRI-41 Add webroot and email as optional inputs to https

### DIFF
--- a/src/triangulum/https.clj
+++ b/src/triangulum/https.clj
@@ -43,39 +43,42 @@
 
 (defn- initial-certificate
   "Creates the initial certbot certificate for a given domain."
-  [domain certbot-dir cert-only]
-  (let [repo-path (.getAbsolutePath (io/file ""))
-        sh-path   (.getAbsolutePath (io/file certbot-dir "renewal-hooks" "deploy" (str domain ".sh")))]
-    (and (sh-wrapper "./"
-                     {}
-                     (str "certbot certonly"
-                          " --quiet"
-                          " --non-interactive"
-                          " --agree-tos"
-                          " -m support@sig-gis.com"
-                          " --webroot"
-                          " -w ./resources/public"
-                          " -d " domain))
-
-         (when-not cert-only
-           ;; The initial certificates are created without the deploy hook to repackage the cert.
-           ;; Create the hook, and then package then the first time.
-           (nil? (spit sh-path
-                       (str "#!/bin/sh"
-                            "\ncd " repo-path
-                            "\nclojure -M:https package-cert -d " domain " -p " certbot-dir)))
-           (sh-wrapper "./"
-                       {}
-                       (str "chmod +x " sh-path))
-           (package-certificate domain certbot-dir)
-           (println "\n*** Initialization complete ***"
-                    "\nYou must now update the permissions for the key file with 'sudo chown -R user:group .key'")))))
+  [email domain certbot-dir cert-only webroot]
+  (sh-wrapper "./"
+              {}
+              (str "certbot certonly"
+                   " --quiet"
+                   " --non-interactive"
+                   " --agree-tos"
+                   " -m " email
+                   " --webroot"
+                   " -w " webroot
+                   " -d " domain))
+  (when-not cert-only
+    (let [repo-path (.getAbsolutePath (io/file ""))
+          hook-path (.getAbsolutePath (io/file certbot-dir "renewal-hooks" "deploy" (str domain ".sh")))]
+      ;; The initial certificates are created without the deploy hook to package the cert.
+      ;; Create the hook, and then package the first time.
+      (spit hook-path
+            (str "#!/bin/sh"
+                 "\ncd " repo-path
+                 "\nclojure -M:https --package-cert -d " domain " -p " certbot-dir))
+      (sh-wrapper "./"
+                  {}
+                  (str "chmod +x " hook-path))
+      (package-certificate domain certbot-dir)
+      (println "\n*** Initialization complete ***"
+               "\nYou must now update the permissions for the key file with 'sudo chown -R user:group .key'"))))
 
 (def ^:private cli-options
-  {:domain    ["-d" "--domain DOMAIN" "Domain for certbot registration."]
+  {:email     ["-e" "--email EMAIL" "Alternative support email."
+               :default "support@sig-gis.com"]
+   :domain    ["-d" "--domain DOMAIN" "Domain for certbot registration."]
    :path      ["-p" "--path PATH" "Alternative path for certbot installation."
                :default "/etc/letsencrypt"]
-   :cert-only ["-o" "--cert-only" "Don't package certificate after initializing."]})
+   :cert-only ["-o" "--cert-only" "Don't package certificate after initializing."]
+   :webroot   ["-w" "--webroot WEBROOT" "Alternative path to the webroot for security test."
+               :default "./resources/public"]})
 
 (def ^:private cli-actions
   {:certbot-init {:description "Initialize certbot."
@@ -87,13 +90,13 @@
   "A set of tools for using certbot as the server certificate manager."
   [& args]
   (let [{:keys [action options]} (get-cli-options args cli-options cli-actions "https")
-        {:keys [domain path cert-only]} options]
+        {:keys [email domain path cert-only webroot]} options]
     (and action
          options
          (if (as-sudo?)
            (let [path (.getAbsolutePath (io/file path))]
              (case action
-               :certbot-init (initial-certificate domain path cert-only)
+               :certbot-init (initial-certificate email domain path cert-only webroot)
                :package-cert (package-certificate domain path)))
            (println "You must run as sudo."))))
   (shutdown-agents))


### PR DESCRIPTION
## Purpose
Add webroot and email as optional inputs to https

## Testing
`clojure -A:https certbot-init -d testing -e test@email.com -w /tmp`


