### PR TITLE
Check folder and not full path for repo

### DIFF
--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -48,7 +48,7 @@ WantedBy=multi-user.target
                           (io/file)
                           (.getAbsolutePath)
                           (remove-end "."))
-        repo-dir      (if (str/includes? full-dir repo)
+        repo-dir      (if (= (.getName (io/file full-dir)) repo)
                         full-dir
                         (-> full-dir
                             (end-with "/")
@@ -66,7 +66,7 @@ WantedBy=multi-user.target
                     {}
                     "systemctl daemon-reload"
                     (str "systemctl enable " service-name)))
-      (println "A repository and directory containing deps.edn must be supplied."))))
+      (println "The directory generated" repo-dir "does not contain a deps.edn file."))))
 
 (defn- disable-systemd [repo]
   (let [service-name (str "cljweb-" repo)]


### PR DESCRIPTION
## Purpose
The check for repo included the whole path string which can lead to false positives.

## Testing
1. With a path /ceo/collect-earth-online, -r cannot be ceo