### PR TITLE
Update systemd template to use server start/stop

### DIFF
--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -17,7 +17,8 @@ After=network.target
 Type=simple
 User=%s
 WorkingDirectory=%s
-ExecStart=/usr/local/bin/clojure -M:run-server %s %s -o logs
+ExecStart=/usr/local/bin/clojure -M:server start %s %s -o logs
+ExecStop=/usr/local/bin/clojure -M:server stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Modifies the systemd template to use the new `-M:server start/stop` commands.
