### PR TITLE
[TRI-75] Allow config.edn to use additional keys

### DIFF
--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -3,7 +3,7 @@
             [clojure.edn        :as edn]
             [clojure.spec.alpha :as s]
             [triangulum.cli     :refer [get-cli-options]]
-            [triangulum.utils   :refer [=keys]]))
+            [triangulum.utils   :refer [subset-keys?]]))
 
 ;;; Specs
 ;; Base spec
@@ -52,7 +52,7 @@
         (do (println "Error: Invalid config file:" file)
             (s/explain ::config config))
 
-        (not (=keys example-config config))
+        (not (subset-keys? example-config config))
         (println "Error: Keys from config.default.edn are missing from:" file)
 
         :else

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -117,14 +117,18 @@
 
 ;; Equality checking
 
-(defn =keys
-  "Whether m1 and m2 contain the same keys."
+(defn subset-keys?
+  "Returns true if m1's keys are a subset of m2's keys, and that any nested maps
+   also maintain the same property.
+
+   Example:
+   `(subset-keys? {:a {:b \"c\"} :d 0} {:a {:b \"e\" :g 42} :d 1 :h 2}) ; => true`"
   [m1 m2]
   (and (set/subset? (-> m1 (keys) (set)) (-> m2 (keys) (set)))
        (reduce (fn [acc [k v]]
                  (and acc
                       (if (map? v)
-                        (=keys v (get m2 k))
+                        (subset-keys? v (get m2 k))
                         true)))
                true
                m1)))

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -2,6 +2,7 @@
   (:import java.io.ByteArrayOutputStream)
   (:require [cognitect.transit :as transit]
             [clojure.string    :as str]
+            [clojure.set       :as set]
             [clojure.data.json :as json]))
 
 ;; Text parsing
@@ -119,7 +120,7 @@
 (defn =keys
   "Whether m1 and m2 contain the same keys."
   [m1 m2]
-  (and (= (keys m1) (keys m2))
+  (and (set/subset? (-> m1 (keys) (set)) (-> m2 (keys) (set)))
        (reduce (fn [acc [k v]]
                  (and acc
                       (if (map? v)

--- a/test/triangulum/utils_test.clj
+++ b/test/triangulum/utils_test.clj
@@ -7,7 +7,7 @@
                                       filterm
                                       parse-as-sh-cmd
                                       mapm
-                                      =keys]]))
+                                      subset-keys?]]))
 
 (deftest end-with-test
   (testing "Appends end-value when string doesn't end with end-value."
@@ -65,16 +65,16 @@
     (is (= (filterm (fn [[_ v]] (odd? v)) test-map)
            {:a 1 :c 3}))))
 
-(deftest =keys-test
-  (testing "Two nested maps with same keys have =keys"
+(deftest subset-keys?-test
+  (testing "Two nested maps with same keys have subset-keys?"
     (is (= true
-           (=keys {:a "b" :c {:d "e"}} {:a "g" :c {:d "f"}}))))
-  (testing "Two nested maps with same keys in different order have =keys"
+           (subset-keys? {:a "b" :c {:d "e"}} {:a "g" :c {:d "f"}}))))
+  (testing "Two nested maps with same keys in different order have subset-keys?"
     (is (= true
-           (=keys {:c {:d "e"} :a "b"} {:a "g" :c {:d "f"}}))))
-  (testing "Two nested maps, one with more keys have =keys"
+           (subset-keys? {:c {:d "e"} :a "b"} {:a "g" :c {:d "f"}}))))
+  (testing "Two nested maps, one with more keys have subset-keys?"
     (is (= true
-           (=keys {:a "b" :c {:d "e"}} {:a "g" :c {:d "f" :h "i"}}))))
-  (testing "Maps without the same keys do NOT have =keys"
+           (subset-keys? {:a "b" :c {:d "e"}} {:a "g" :c {:d "f" :h "i"}}))))
+  (testing "Maps without the same keys do NOT have subset-keys?"
     (is (= false
-           (=keys {:a "b" :c {:d "e"}} {:a "g" :c {:y "z"}})))))
+           (subset-keys? {:a "b" :c {:d "e"}} {:a "g" :c {:y "z"}})))))

--- a/test/triangulum/utils_test.clj
+++ b/test/triangulum/utils_test.clj
@@ -68,7 +68,13 @@
 (deftest =keys-test
   (testing "Two nested maps with same keys have =keys"
     (is (= true
-           (=keys {:a "b" :c {:e "d"}} {:a "g" :c {:e "f"}}))))
+           (=keys {:a "b" :c {:d "e"}} {:a "g" :c {:d "f"}}))))
+  (testing "Two nested maps with same keys in different order have =keys"
+    (is (= true
+           (=keys {:c {:d "e"} :a "b"} {:a "g" :c {:d "f"}}))))
+  (testing "Two nested maps, one with more keys have =keys"
+    (is (= true
+           (=keys {:a "b" :c {:d "e"}} {:a "g" :c {:d "f" :h "i"}}))))
   (testing "Maps without the same keys do NOT have =keys"
     (is (= false
-           (=keys {:a "b" :c {:e "d"}} {:a "g" :c {:y "z"}})))))
+           (=keys {:a "b" :c {:d "e"}} {:a "g" :c {:y "z"}})))))


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Allow `config.edn` to have more keys and keys out of order compared to `config.default.edn`

## Related Issues
Closes TRI-75

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
Run tests (`clj -M:test`)
