### PR TITLE
TRI-84 Fix default values overwrite config.edn

### DIFF
--- a/src/triangulum/cli.clj
+++ b/src/triangulum/cli.clj
@@ -58,13 +58,40 @@
       (not-every? options requires)
       (error-str action requires cli-options))))
 
+(defn- get-option-default [option]
+  (reduce (fn [{:keys [option default]} cur]
+            (cond
+              (= :default cur)
+              {:option option
+               :default true}
+
+              (= default true)
+              {:option option
+               :default cur}
+
+              :else
+              {:option (conj option cur)
+               :default default}))
+          {:option [] :default nil}
+          option))
+
+(defn- separate-options-defaults [options]
+  (reduce (fn [acc [k v]]
+            (let [{:keys [option default]} (get-option-default v)]
+              (-> acc
+                  (assoc-in [:options k] option)
+                  (assoc-in [:defaults k] default))))
+          {:options {} :defaults {}}
+          options))
+
 (defn get-cli-options
   "Checks for a valid call from the CLI and returns the users options."
   [args cli-options cli-actions alias-str & [config]]
-  (let [{:keys [arguments errors options]} (->> cli-options
+  (let [{:keys [options defaults]} (separate-options-defaults cli-options)
+        {:keys [arguments errors options]} (->> options
                                                 (vals)
                                                 (parse-opts args))
-        combined-options (merge config options) ; config file is default, cli params can overwrite.
+        combined-options (merge defaults config options) ; defaults, config file, then cli params can overwrite.
         action           (keyword (first arguments))
         error-msg        (check-errors arguments errors combined-options action cli-options cli-actions)]
     (if error-msg

--- a/src/triangulum/cli.clj
+++ b/src/triangulum/cli.clj
@@ -59,21 +59,21 @@
       (error-str action requires cli-options))))
 
 (defn- get-option-default [option]
-  (reduce (fn [{:keys [option default]} cur]
-            (cond
-              (= :default cur)
-              {:option option
-               :default true}
+  (loop [cur     (first option)
+         tail    (next option)
+         option  []]
+    (cond
+      (nil? cur)
+      {:option option :default nil}
 
-              (= default true)
-              {:option option
-               :default cur}
+      (= :default cur)
+      {:option  (vec (concat option (next tail)))
+       :default (first tail)}
 
-              :else
-              {:option (conj option cur)
-               :default default}))
-          {:option [] :default nil}
-          option))
+      :else
+      (recur (first tail)
+             (next tail)
+             (conj option cur)))))
 
 (defn- separate-options-defaults [options]
   (reduce (fn [acc [k v]]

--- a/src/triangulum/cli.clj
+++ b/src/triangulum/cli.clj
@@ -61,19 +61,19 @@
 (defn- get-option-default [option]
   (loop [cur     (first option)
          tail    (next option)
-         option  []]
+         result  []]
     (cond
       (nil? cur)
-      {:option option :default nil}
+      {:option result :default nil}
 
       (= :default cur)
-      {:option  (vec (concat option (next tail)))
+      {:option  (vec (concat result (next tail)))
        :default (first tail)}
 
       :else
       (recur (first tail)
              (next tail)
-             (conj option cur)))))
+             (conj result cur)))))
 
 (defn- separate-options-defaults [options]
   (reduce (fn [acc [k v]]

--- a/test/triangulum/cli_test.clj
+++ b/test/triangulum/cli_test.clj
@@ -1,0 +1,63 @@
+(ns triangulum.cli-test
+  (:require [clojure.test    :refer [are deftest testing]]
+            [triangulum.cli  :refer [get-cli-options]]))
+
+(def ^:private cli-actions {:test {:description "Starts the test."}})
+
+(def ^:private cli-options
+  {:int  ["-i" "--int INT" "Integer option, defaults to 1"
+          :parse-fn #(if (int? %) % (Integer/parseInt %))
+          :default 1]
+   :str  ["-s" "--str STING" "String option, defaults to 'test'"
+          :default "test"]
+   :flag ["-f" "--flag" "Boolean option, defaults to false."
+          :default false]
+   :set  ["-t" "--set SET" "Set option, can be either \"big\", \"medium\", or \"small\". Defaults to \"small\"."
+          :default "small"
+          :validate [#{"big" "medium" "small"} "Must be \"big\", \"medium\", or \"small\""]]})
+
+(deftest test-cli-options
+    (testing "Config uses default values."
+      (let [config   {}
+            f        #(get-cli-options (concat ["test"] %) cli-options cli-actions "server" config)]
+        (are [result args] (let [{:keys [options]} (f args)]
+                             (= ((first result) options)
+                                (second result)))
+             [:int 1]          []
+             [:str "test"] []
+             [:flag false]      []
+             [:set "small"]   [])))
+
+    (testing "CLI flag overrides the default values."
+      (let [config   {}
+            f        #(get-cli-options (concat ["test"] %) cli-options cli-actions "server" config)]
+        (are [result args] (let [{:keys [options]} (f args)]
+                             (= ((first result) options)
+                                (second result)))
+             [:int 3]          ["-i" "3"]
+             [:str "override"] ["-s" "override"]
+             [:flag true]      ["-f"]
+             [:set "medium"]   ["-t" "medium"]))
+
+
+    (testing "Config overrides the default values."
+      (let [config   {:int 3 :str "override" :flag true :set "medium"}
+            f        #(get-cli-options (concat ["test"] %) cli-options cli-actions "server" config)]
+        (are [result args] (let [{:keys [options]} (f args)]
+                             (= ((first result) options)
+                                (second result)))
+             [:int 3]          []
+             [:str "override"] []
+             [:flag true]      []
+             [:set "medium"]   [])))
+
+    (testing "CLI overrides the config values."
+      (let [config   {:int 10 :str "not-valid" :flag false :set "large"}
+            f        #(get-cli-options (concat ["test"] %) cli-options cli-actions "server" config)]
+        (are [result args] (let [{:keys [options]} (f args)]
+                             (= ((first result) options)
+                                (second result)))
+             [:int 3]          ["-i" "3"]
+             [:str "override"] ["-s" "override"]
+             [:flag true]      ["-f"]
+             [:set "medium"]   ["-t" "medium"])))))

--- a/test/triangulum/cli_test.clj
+++ b/test/triangulum/cli_test.clj
@@ -1,25 +1,25 @@
 (ns triangulum.cli-test
-  (:require [clojure.test    :refer [are is deftest testing]]
-            [triangulum.cli  :refer [get-cli-options]]))
+  (:require [clojure.test   :refer [are is deftest testing]]
+            [triangulum.cli :refer [get-cli-options]]))
 
 (def ^:private cli-actions {:run-test {:description "Starts the test."}})
 
 (def ^:private cli-options
   {:int  ["-i" "--int INT" "Integer option, defaults to 1"
           :parse-fn #(if (int? %) % (Integer/parseInt %))
-          :default 1]
+          :default  1]
    :str  ["-s" "--str STING" "String option, defaults to 'test'"
           :default "test"]
    :flag ["-f" "--flag" "Boolean option, defaults to false."
           :default false]
    :set  ["-t" "--set SET" "Set option, can be either \"big\", \"medium\", or \"small\". Defaults to \"small\"."
-          :default "small"
+          :default  "small"
           :validate [#{"big" "medium" "small"} "Must be \"big\", \"medium\", or \"small\""]]})
 
 (deftest test-cli-options
   (let [defaults {:int 1 :str "test" :flag false :set "small"}
-        sut (fn [args config]
-              (get-cli-options (concat ["run-test"] args) cli-options cli-actions "run-test" config))]
+        sut      (fn [args config]
+                   (get-cli-options (concat ["run-test"] args) cli-options cli-actions "run-test" config))]
 
     (testing "Config uses default values."
       (is (= (:options (sut [] {})) defaults)))


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Strips the :default parameter from the CLI options to be manually
merged later.

Prioritizes CLI values as follows:
1. CLI Flags
2. config.edn
3. Default values

## Related Issues
Closes TRI-84

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
Run `clj -M:test`
