### PR TITLE
TRI-78 Update systemd to use notify

### DIFF
--- a/README.org
+++ b/README.org
@@ -242,7 +242,21 @@ your ~:aliases~ section in the ~deps.edn~ file:
 {:aliases {:systemd {:main-opts ["-m" "triangulum.systemd"]}}}
 #+end_src
 
-And then running:
+Modify your app code to call ~(triangulum.notify/ready!)~ after all of your
+application's services are started:
+#+begin_src clojure
+(ns <app>.server
+  (:require [triangulum.notify :as notify]))
+...
+
+(defn app-start []
+  (reset! db (jdbc/connect!))
+  (reset! queues (q/start!))
+  (reset! server (ring/start-server!)
+  (when (notify/available?) (notify/ready!))))
+#+end_src
+
+And then run:
 #+begin_src sh
 sudo clojure -M:systemd enable -r <REPO> -u <USER> [-p HTTP PORT] [-P HTTPS PORT] [-d REPO DIRECTORY]
 #+end_src

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,8 @@
         org.xerial/sqlite-jdbc    {:mvn/version "3.30.1"}
         seancorfield/next.jdbc    {:mvn/version "1.1.613"}
         seancorfield/depstar      {:mvn/version "2.0.165"}
-        deps-deploy/deps-deploy   {:mvn/version "0.0.12"}}
+        deps-deploy/deps-deploy   {:mvn/version "0.0.12"}
+        info.faljse/SDNotify      {:mvn/version "1.3"}}
 
  :aliases {:build-db   {:main-opts ["-m" "triangulum.build-db"]}
            :https      {:main-opts ["-m" "triangulum.https"]}

--- a/src/triangulum/notify.clj
+++ b/src/triangulum/notify.clj
@@ -1,0 +1,29 @@
+(ns triangulum.notify
+  (:import [info.faljse.SDNotify SDNotify]))
+
+;; Notify
+(defn available?
+  "Checks if this process is a process managed by systemd."
+  []
+  (SDNotify/isAvailable))
+
+(defn ready!
+  "Sends ready message to systemd. Systemd file must include `Type=notify` to be used."
+  []
+  (SDNotify/sendNotify))
+
+(defn reloading!
+  "Sends reloading message to systemd. Must call `send-notify!` once reloading
+   has been completed."
+  []
+  (SDNotify/sendReloading))
+
+(defn stopping!
+  "Sends stopping message to systemd."
+  []
+  (SDNotify/sendStopping))
+
+(defn send-status!
+  "Sends status message to systemd. (e.g. `(send-status! \"READY=1\")`)."
+  [s]
+  (SDNotify/sendStatus s))

--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -14,10 +14,10 @@ Description=A service to launch a server written in clojure
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
 User=%s
 WorkingDirectory=%s
-ExecStart=/usr/local/bin/clojure -M:server start %s %s -o logs
+ExecStart=/usr/local/bin/clojure -M:server start %s %s
 ExecStop=/usr/local/bin/clojure -M:server stop
 
 [Install]


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Modify systemd template use the `Type=notify` for services.

Added the `triangulum.notify` namespace, which wraps [SDNotify](https://github.com/faljse/SDNotify) library, which is a wrapper around [sd_notify](https://www.freedesktop.org/software/systemd/man/sd_notify.html).

New functions:
* `notify/available?`
* `notify/ready!`
* `notify/reloading!`
* `notify/stopping!`
* `notify/send-status!`

Updated the README to include new instructions for using `triangulum.notify`

## Related Issues
Closes TRI-78

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
