### PR TITLE
Fix keywords to match CLI --option

### DIFF
--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -102,7 +102,7 @@
   (map? (read-config file)))
 
 (def ^:private cli-options
-  {:validate ["-f" "--file FILE" "Configuration file to validate."]})
+  {:file ["-f" "--file FILE" "Configuration file to validate."]})
 
 (def ^:private cli-actions
   {:validate {:description "Validates the configuration file (default: config.edn)."

--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -82,7 +82,7 @@ WantedBy=multi-user.target
 
 (def ^:private cli-options
   {:all       ["-a" "--all" "Starts, stops, or restarts all cljweb services when specified with the corresponding action."]
-   :directory ["-d" "--dir DIR" "Optional path to repo directory when enabling the service. Will default to the current directory."
+   :dir       ["-d" "--dir DIR" "Optional path to repo directory when enabling the service. Will default to the current directory."
                :default "./"]
    :http      ["-p" "--http HTTP" "Optional http port to run the server."]
    :https     ["-P" "--https HTTPS" "Optional https port to run the server."]

--- a/test/triangulum/cli_test.clj
+++ b/test/triangulum/cli_test.clj
@@ -8,7 +8,7 @@
   {:int  ["-i" "--int INT" "Integer option, defaults to 1"
           :parse-fn #(if (int? %) % (Integer/parseInt %))
           :default  1]
-   :str  ["-s" "--str STING" "String option, defaults to 'test'"
+   :str  ["-s" "--str STRING" "String option, defaults to 'test'"
           :default "test"]
    :flag ["-f" "--flag" "Boolean option, defaults to false."
           :default false]


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
The `cli-options` must match the the generated keyword from the Clojure CLI parser (e.g. `"--dir DIR" -> :dir`)

## Related Issues
Related to TRI-84

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
