### PR TITLE
TRI-7 Add 'clj -M:build-db migrate' command

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -21,17 +21,6 @@ jobs:
           - 5432:5432
 
     steps:
-      - name: Install PostgreSQL client
-        run: |
-          apt-get update
-          apt-get install --yes postgresql-client
-
-      # queries database with postgres client
-      - name: Query database
-        run: psql -h postgres -d postgres_db -U postgres_user -c 'SELECT 1;'
-        env:
-          PGPASSWORD: SPECIALPASSWORD
-
       - uses: actions/checkout@v2
       - name: Run tests
         uses: vouch-opensource/tools.deps-build@1.0.1

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -7,42 +7,9 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    env:
-      PGDATABASE: postgres
-      PGUSERNAME: postgres
-      PGPASSWORD: postgres
-
-    services:
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_HOST: postgres
-          POSTGRES_PORT: 5432
-          POSTGRES_DB: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
 
     steps:
-      - name: PG prerequisites
-        run: sudo apt-get update
-
-      - name: PG prerequisites
-        run: sudo apt-get install -y libpq-dev
-
-      - name: Test connection
-        run: |
-          psql -h '127.0.0.1' -p 5432 -U postgres \
-          -d github_actions -c "SELECT version();"
-
       - uses: actions/checkout@v2
       - name: Run tests
         uses: vouch-opensource/tools.deps-build@1.0.1

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -10,7 +10,30 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+      image: postgres:latest
+      env:
+        POSTGRES_DB: postgres
+        POSTGRES_USER: postgres
+        POSTGRES_PASSWORD: SPECIALPASSWORD
+      ports:
+        - 5432:5432
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Run tests
-      uses: vouch-opensource/tools.deps-build@1.0.1
+      - name: Install PostgreSQL client
+        run: |
+          apt-get update
+          apt-get install --yes postgresql-client
+
+      # queries database with postgres client
+      - name: Query database
+        run: psql -h postgres -d postgres_db -U postgres_user -c 'SELECT 1;'
+        env:
+          PGPASSWORD: SPECIALPASSWORD
+
+      - uses: actions/checkout@v2
+      - name: Run tests
+        uses: vouch-opensource/tools.deps-build@1.0.1
+        env:
+          PGPASSWORD: SPECIALPASSWORD

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -21,6 +21,12 @@ jobs:
           - 5432:5432
 
     steps:
+      - name: psycopg2 prerequisites
+        run: sudo apt-get update
+
+      - name: psycopg2 prerequisites
+        run: sudo apt-get install -y libpq-dev
+
       - uses: actions/checkout@v2
       - name: Run tests
         uses: vouch-opensource/tools.deps-build@1.0.1

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -9,26 +9,40 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      PGDATABASE: postgres
+      PGUSERNAME: postgres
+      PGPASSWORD: postgres
 
     services:
       postgres:
         image: postgres:latest
         env:
+          POSTGRES_HOST: postgres
+          POSTGRES_PORT: 5432
           POSTGRES_DB: postgres
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: SPECIALPASSWORD
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           - 5432:5432
 
     steps:
-      - name: psycopg2 prerequisites
+      - name: PG prerequisites
         run: sudo apt-get update
 
-      - name: psycopg2 prerequisites
+      - name: PG prerequisites
         run: sudo apt-get install -y libpq-dev
+
+      - name: Test connection
+        run: |
+          psql -h '127.0.0.1' -p 5432 -U postgres \
+          -d github_actions -c "SELECT version();"
 
       - uses: actions/checkout@v2
       - name: Run tests
         uses: vouch-opensource/tools.deps-build@1.0.1
-        env:
-          PGPASSWORD: SPECIALPASSWORD

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -12,13 +12,13 @@ jobs:
 
     services:
       postgres:
-      image: postgres:latest
-      env:
-        POSTGRES_DB: postgres
-        POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: SPECIALPASSWORD
-      ports:
-        - 5432:5432
+        image: postgres:latest
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: SPECIALPASSWORD
+        ports:
+          - 5432:5432
 
     steps:
       - name: Install PostgreSQL client

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pom.xml
 target/
 .rebel_readline_history
 config.edn
+tmp/

--- a/README.org
+++ b/README.org
@@ -420,7 +420,7 @@ application's services are started:
 
 And then run:
 #+begin_src sh
-clojure -M:systemd enable -r $REPO -u $USER [-p $HTTP_PORT] [-P $HTTPS_PORT] [-d $REPO_DIRECTORY] [-A $EXTRA_ALIASES]
+clojure -M:systemd enable -r $REPO [-p $HTTP_PORT] [-P $HTTPS_PORT] [-d $REPO_DIRECTORY] [-A $EXTRA_ALIASES]
 #+end_src
 
 This will install a file named ~cljweb-<repo>.service~ into the

--- a/README.org
+++ b/README.org
@@ -573,6 +573,11 @@ Checks if the keys of one map are a subset of another map's keys, including nest
 ****** resolve-foreign-symbol
 
 Attempts to require a namespace-qualified symbol's namespace and resolve the symbol within that namespace to a value.
+
+****** delete-recursively
+
+Recursively delete all files and directories under the given directory.Traverses the directory tree in reverse depth-first order.
+
 *** triangulum.type-conversion
 
 The triangulum.type-conversion namespace provides a collection of functions for converting between different data types and formats, including conversions between numbers, booleans, JSON, and PostgreSQL data types.

--- a/deps.edn
+++ b/deps.edn
@@ -41,7 +41,7 @@
            :test-db    {:extra-paths ["test" "tmp"]
                         :extra-deps  {com.cognitect/test-runner
                                       {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                       :sha "b6b3193fcc42659d7e46ecd1884a228993441182"}}
+                                       :sha     "b6b3193fcc42659d7e46ecd1884a228993441182"}}
                         :main-opts   ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"
                                       "-m" "cognitect.test-runner"
                                       "--include" ":db"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -28,4 +28,13 @@
                                       {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                        :sha     "b6b3193fcc42659d7e46ecd1884a228993441182"}}
                         :main-opts   ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"
-                                      "-m" "cognitect.test-runner"]}}}
+                                      "-m" "cognitect.test-runner"
+                                      "--exclude" ":db"]}
+           :test-db    {:extra-paths ["test" "tmp"]
+                        :extra-deps  {com.cognitect/test-runner
+                                      {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                       :sha     "b6b3193fcc42659d7e46ecd1884a228993441182"}}
+                        :main-opts   ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"
+                                      "-m" "cognitect.test-runner"
+                                      "--include" ":db"]}}}
+

--- a/deps.edn
+++ b/deps.edn
@@ -1,16 +1,16 @@
 {:paths ["src"]
 
- :deps {com.cognitect/transit-clj {:mvn/version "1.0.324"}
-        org.clojure/clojure       {:mvn/version "1.10.3"}
-        org.clojure/data.json     {:mvn/version "1.0.0"}
-        org.clojure/tools.cli     {:mvn/version "1.0.206"}
-        org.clojure/test.check    {:mvn/version "0.9.0"}
-        org.postgresql/postgresql {:mvn/version "42.2.10"}
-        org.xerial/sqlite-jdbc    {:mvn/version "3.30.1"}
-        seancorfield/next.jdbc    {:mvn/version "1.1.613"}
-        seancorfield/depstar      {:mvn/version "2.0.165"}
-        deps-deploy/deps-deploy   {:mvn/version "0.0.12"}
-        info.faljse/SDNotify      {:mvn/version "1.3"}}
+ :deps {com.cognitect/transit-clj         {:mvn/version "1.0.324"}
+        org.clojure/clojure               {:mvn/version "1.10.3"}
+        org.clojure/data.json             {:mvn/version "1.0.0"}
+        org.clojure/tools.cli             {:mvn/version "1.0.206"}
+        org.clojure/test.check            {:mvn/version "0.9.0"}
+        org.postgresql/postgresql         {:mvn/version "42.2.10"}
+        org.xerial/sqlite-jdbc            {:mvn/version "3.30.1"}
+        com.github.seancorfield/next.jdbc {:mvn/version "1.2.761"}
+        seancorfield/depstar              {:mvn/version "2.0.165"}
+        deps-deploy/deps-deploy           {:mvn/version "0.0.12"}
+        info.faljse/SDNotify              {:mvn/version "1.3"}}
 
  :aliases {:build-db   {:main-opts ["-m" "triangulum.build-db"]}
            :https      {:main-opts ["-m" "triangulum.https"]}
@@ -23,7 +23,7 @@
            :deploy-jar {:extra-deps {seancorfield/depstar    {:mvn/version "2.0.165"}
                                      deps-deploy/deps-deploy {:mvn/version "0.0.12"}}
                         :main-opts  ["-m" "triangulum.deploy" "sig-gis" "triangulum"]}
-           :test       {:extra-paths ["test"]
+           :test       {:extra-paths ["test" "tmp"]
                         :extra-deps  {com.cognitect/test-runner
                                       {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                        :sha     "b6b3193fcc42659d7e46ecd1884a228993441182"}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,25 +1,25 @@
 {:paths ["src"]
 
- :deps {babashka/process          {:mvn/version "0.4.16"}
-        bk/ring-gzip              {:mvn/version "0.3.0"}
-        cider/cider-nrepl         {:mvn/version "0.29.0"}
-        clj-http/clj-http         {:mvn/version "3.12.3"}
-        com.cognitect/transit-clj {:mvn/version "1.0.324"}
-        org.clojure/clojure       {:mvn/version "1.11.1"}
-        org.clojure/data.json     {:mvn/version "1.0.0"}
-        org.clojure/tools.cli     {:mvn/version "1.0.206"}
-        org.clojure/test.check    {:mvn/version "0.9.0"}
-        com.draines/postal        {:mvn/version "2.0.3"}
-        org.postgresql/postgresql {:mvn/version "42.2.10"}
-        org.xerial/sqlite-jdbc    {:mvn/version "3.30.1"}
-        seancorfield/next.jdbc    {:mvn/version "1.2.659"}
-        seancorfield/depstar      {:mvn/version "2.0.165"}
-        deps-deploy/deps-deploy   {:mvn/version "0.0.12"}
-        ring/ring                 {:mvn/version "1.8.2"}
-        ring/ring-headers         {:mvn/version "0.3.0"}
-        ring/ring-json            {:mvn/version "0.5.0"}
-        ring/ring-ssl             {:mvn/version "0.3.0"}
-        info.faljse/SDNotify      {:mvn/version "1.3"}}
+ :deps {babashka/process                  {:mvn/version "0.4.16"}
+        bk/ring-gzip                      {:mvn/version "0.3.0"}
+        cider/cider-nrepl                 {:mvn/version "0.29.0"}
+        clj-http/clj-http                 {:mvn/version "3.12.3"}
+        com.cognitect/transit-clj         {:mvn/version "1.0.324"}
+        org.clojure/clojure               {:mvn/version "1.11.1"}
+        org.clojure/data.json             {:mvn/version "1.0.0"}
+        org.clojure/tools.cli             {:mvn/version "1.0.206"}
+        org.clojure/test.check            {:mvn/version "0.9.0"}
+        com.draines/postal                {:mvn/version "2.0.3"}
+        org.postgresql/postgresql         {:mvn/version "42.2.10"}
+        org.xerial/sqlite-jdbc            {:mvn/version "3.30.1"}
+        com.github.seancorfield/next.jdbc {:mvn/version "1.3.874"}
+        seancorfield/depstar              {:mvn/version "2.0.165"}
+        deps-deploy/deps-deploy           {:mvn/version "0.0.12"}
+        ring/ring                         {:mvn/version "1.8.2"}
+        ring/ring-headers                 {:mvn/version "0.3.0"}
+        ring/ring-json                    {:mvn/version "0.5.0"}
+        ring/ring-ssl                     {:mvn/version "0.3.0"}
+        info.faljse/SDNotify              {:mvn/version "1.3"}}
 
  :aliases {:build-db   {:main-opts ["-m" "triangulum.build-db"]}
            :config     {:main-opts ["-m" "triangulum.config"]}

--- a/src/triangulum/build_db.clj
+++ b/src/triangulum/build_db.clj
@@ -168,7 +168,7 @@
                    :requires    [:dbname]}
    :restore       {:description "Restore a database from a .dump file created by pg_dump."
                    :requires    [:file]}
-   :apply-changes {:description "Applies the migration files under `src/sql/changes` in chronological order."
+   :migrate       {:description "Applies the migration files under `src/sql/changes` in chronological order."
                    :requires    [:dbname :user :password]}})
 
 (defn -main

--- a/src/triangulum/build_db.clj
+++ b/src/triangulum/build_db.clj
@@ -1,5 +1,5 @@
 (ns triangulum.build-db
-  (:import [java.io File])
+  (:import java.io.File)
   (:require [clojure.java.io    :as io]
             [clojure.java.shell :as sh]
             [clojure.string     :as str]
@@ -160,16 +160,16 @@
    :verbose    ["-v" "--verbose"             "Print verbose PostgreSQL output."]})
 
 (def ^:private cli-actions
-  {:backup        {:description "Create a .dump backup file using pg_dump."
-                   :requires    [:dbname :file]}
-   :build-all     {:description "Build / rebuild the entire data base."
-                   :requires    [:dbname]}
-   :functions     {:description "Build / rebuild all functions."
-                   :requires    [:dbname]}
-   :restore       {:description "Restore a database from a .dump file created by pg_dump."
-                   :requires    [:file]}
-   :migrate       {:description "Applies the migration files under `src/sql/changes` in chronological order."
-                   :requires    [:dbname :user :password]}})
+  {:backup    {:description "Create a .dump backup file using pg_dump."
+               :requires    [:dbname :file]}
+   :build-all {:description "Build / rebuild the entire data base."
+               :requires    [:dbname]}
+   :functions {:description "Build / rebuild all functions."
+               :requires    [:dbname]}
+   :restore   {:description "Restore a database from a .dump file created by pg_dump."
+               :requires    [:file]}
+   :migrate   {:description "Applies the migration files under `src/sql/changes` in chronological order."
+               :requires    [:dbname :user :password]}})
 
 (defn -main
   "A set of tools for building and maintaining the project database with Postgres."

--- a/src/triangulum/migrate.clj
+++ b/src/triangulum/migrate.clj
@@ -1,0 +1,127 @@
+(ns triangulum.migrate
+  (:require [clojure.java.io      :as io]
+            [clojure.set          :refer [difference]]
+            [clojure.string       :as str]
+            [next.jdbc            :as jdbc]
+            [next.jdbc.result-set :refer [as-unqualified-lower-maps]]
+            [triangulum.security  :refer [hash-file]]))
+
+;; Constants
+(def ^:dynamic *migrations-dir* "./src/sql/changes/")
+
+;; Helper Fns
+
+(defn- migration-path [filename]
+  (str *migrations-dir* "/" filename))
+
+(defn- get-conn [database user user-pass]
+  (jdbc/get-connection {:dbtype                "postgresql"
+                        :dbname                database
+                        :user                  user
+                        :password              user-pass
+                        :reWriteBatchedInserts true}))
+
+(defn- get-migrations-dir []
+  (io/make-parents *migrations-dir*)
+  *migrations-dir*)
+
+(defn- get-migration-files []
+  (->> (get-migrations-dir)
+       (io/file)
+       (file-seq)
+       (filter #(.isFile %))
+       (map #(.getName %))
+       (filter #(str/ends-with? % ".sql"))
+       (sort)))
+
+(defn- file-changed? [filename prev-file-hash]
+  (not (= prev-file-hash (hash-file (migration-path filename)))))
+
+(defn- get-completed-changes [db-conn]
+  (let [completed     (jdbc/execute! db-conn ["SELECT filename, hash
+                                              FROM tri.migrations
+                                              ORDER BY created_date"]
+                                     {:builder-fn as-unqualified-lower-maps})
+        files-changed (filter #(file-changed? (:filename %) (:hash %)) completed)]
+    (if (pos? (count files-changed))
+      (throw (Exception. (format "Error: Migrations have been modified: %s"
+                                 (str/join ", " (map :filename files-changed)))))
+      (map :filename completed))))
+
+(defn- set-completed! [db-conn filename]
+  (jdbc/execute! db-conn ["INSERT INTO tri.migrations
+                          (filename, hash)
+                          VALUES (?, ?)"
+                          filename
+                          (hash-file (migration-path filename))]))
+
+(defn- migration-error [e filename remaining-files]
+  (str (format "Error: Did not complete migration %s and all migrations after:\n" filename)
+       (str/join "\n- " remaining-files)
+       "\n\n"
+       e))
+
+(defn- apply-migration! [db-conn filename verbose?]
+  (when verbose? (println (format "Migrating change %s " filename)))
+  (let [transaction #(jdbc/with-transaction [tx db-conn]
+                       (jdbc/execute! tx [(slurp (str *migrations-dir* "/" filename))]))
+        result (try
+                 (transaction)
+                 (catch Exception e {:error (ex-message e)}))]
+    (if (:error result)
+      result
+      (when verbose? (println (format "Completed migration %s" filename))))))
+
+(defn- setup-migrations-table! [db-conn]
+  (let [migration-exists? (jdbc/execute-one! db-conn ["SELECT * FROM pg_catalog.pg_tables
+                                                 WHERE schemaname = 'tri'
+                                                 AND tablename = 'migrations';"])]
+    (when-not migration-exists?
+      (jdbc/with-transaction [tx db-conn]
+        (jdbc/execute! tx ["CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";"])
+        (jdbc/execute! tx ["CREATE SCHEMA IF NOT EXISTS tri;"])
+        (jdbc/execute! tx ["CREATE TABLE IF NOT EXISTS tri.migrations (
+                           migration_id uuid      PRIMARY KEY DEFAULT uuid_generate_v4 (),
+                           filename     VARCHAR   NOT NULL,
+                           hash         VARCHAR   NOT NULL,
+                           created_date TIMESTAMP DEFAULT now());"])))))
+
+;; Public fns
+
+(defn migrate!
+  "Performs the database migrations stored in the `src/sql/changes/` directory.
+   Migrations must be stored in chronological order (e.g. `2021-02-28_add-users-table.sql`).
+
+   Migrations run inside of a transaction block to ensure the entire migration is
+   completed prior to being committed to the database.
+
+   Currently, this tool does not support rollbacks.
+
+   If a migration fails, all migrations which follow it will be cancelled.
+
+   Migrations which have been completed are stored in a table `tri.migrations`,
+   and include a SHA-256 hash of the migration file contents. If a migration has
+   been altered, the migrations will fail. This is to ensure consistency as migrations
+   are added."
+  [database user user-pass verbose?]
+  (when verbose? (println "Applying changes..."))
+
+  (with-open [conn (get-conn database user user-pass)]
+    (let [all-files   (get-migration-files)
+          _           (setup-migrations-table! conn)
+          completed   (get-completed-changes conn)
+          new-changes (sort (difference (set all-files) (set completed)))]
+
+      (when verbose? (println (format "Found %s new change files." (count new-changes))))
+
+      (when (pos? (count new-changes))
+        (loop [file      (first new-changes)
+               changes   (next new-changes)]
+          (when (some? file)
+            (if-let [{error :error} (apply-migration! conn file verbose?)]
+              (throw (Exception. (migration-error error file changes)))
+              (do
+                (set-completed! conn file)
+                (recur (first changes) (next changes))))))))
+
+    (when verbose? (println "Completed migrations."))))

--- a/src/triangulum/migrate.clj
+++ b/src/triangulum/migrate.clj
@@ -7,7 +7,9 @@
             [triangulum.security  :refer [hash-file]]))
 
 ;; Constants
-(def ^:dynamic *migrations-dir* "./src/sql/changes/")
+(def ^{:dynamic true :doc ""}
+  *migrations-dir*
+  "./src/sql/changes/")
 
 ;; Helper Fns
 

--- a/src/triangulum/migrate.clj
+++ b/src/triangulum/migrate.clj
@@ -33,7 +33,7 @@
        (io/file)
        (file-seq)
        (filter #(.isFile ^File %))
-       (map #(.getName %))
+       (map #(.getName ^File %))
        (filter #(str/ends-with? % ".sql"))
        (sort)))
 
@@ -59,8 +59,8 @@
                           (hash-file (migration-path filename))]))
 
 (defn- migration-error [e file-name new-changes]
-  (str (format "Error: Did not complete migration %s and all migrations after:\n-" file-name)
-       (str/join "\n-" (rest (drop-while #(not= file-name %) new-changes)))
+  (str (format "Error: Did not complete migration %s and all migrations after:\n- " file-name)
+       (str/join "\n- " (rest (drop-while #(not= file-name %) new-changes)))
        "\n\n"
        e))
 

--- a/src/triangulum/migrate.clj
+++ b/src/triangulum/migrate.clj
@@ -7,7 +7,7 @@
             [triangulum.security  :refer [hash-file]]))
 
 ;; Constants
-(def ^{:dynamic true :doc ""}
+(def ^{:dynamic true :doc "Location of migrations dir"}
   *migrations-dir*
   "./src/sql/changes/")
 

--- a/src/triangulum/migrate.clj
+++ b/src/triangulum/migrate.clj
@@ -5,8 +5,8 @@
             [clojure.string       :as str]
             [next.jdbc            :as jdbc]
             [next.jdbc.result-set :refer [as-unqualified-lower-maps]]
-            [triangulum.security  :refer [hash-file]]
-            [triangulum.utils :refer [nil-on-error]]))
+            [triangulum.errors    :refer [nil-on-error]]
+            [triangulum.security  :refer [hash-file]]))
 
 ;;; Constants
 

--- a/src/triangulum/security.clj
+++ b/src/triangulum/security.clj
@@ -1,6 +1,5 @@
 (ns triangulum.security
-  (:require [clojure.java.io :as io])
-  (:import [java.security MessageDigest]))
+  (:import java.security.MessageDigest))
 
 ;; https://gist.github.com/kisom/1698245
 (defn hash-digest
@@ -8,12 +7,12 @@
   ([input] (hash-digest input "SHA-256"))
   ([input hash-algo]
    (let [md (doto (MessageDigest/getInstance hash-algo)
-              (.update (.getBytes input)))]
+              (.update (.getBytes ^String input)))]
      (apply str (map #(format "%02x" (bit-and % 0xff)) (.digest md))))))
 
 (defn hash-file
   "Returns the sha256 digest of a file."
   [filename]
-  (-> (io/file filename)
+  (-> filename
       (slurp)
       (hash-digest)))

--- a/src/triangulum/security.clj
+++ b/src/triangulum/security.clj
@@ -1,0 +1,30 @@
+(ns triangulum.security
+  (:require [clojure.java.io :as io])
+  (:import [java.security MessageDigest]))
+
+;; https://gist.github.com/kisom/1698245
+(defn hash-str
+  "Returns the hex digest of string. Defaults to SHA-256 hash."
+  ([input] (hash-str input "SHA-256"))
+  ([^java.lang.String input hash-algo]
+     (if (string? input)
+       (let [md (MessageDigest/getInstance hash-algo)]
+         (.update md (.getBytes input))
+         (let [digest (.digest md)]
+           (apply str (map #(format "%02x" (bit-and % 0xff)) digest))))
+       (do
+         (println "Invalid input to hexdigst! Expected string, got" (type input))
+         nil))))
+
+(defn hash-file
+  "Returns the sha256 digest of a file."
+  [filename]
+  (when (.isFile (io/file filename))
+    (-> filename
+        (slurp)
+        (hash-str))))
+
+(defn compare-sha256
+  "Compare an object to a hash; true if (= (hash obj) ref-hash)."
+  [obj ref-hash]
+  (= ref-hash (hash-str obj "SHA-256")))

--- a/src/triangulum/security.clj
+++ b/src/triangulum/security.clj
@@ -3,23 +3,17 @@
   (:import [java.security MessageDigest]))
 
 ;; https://gist.github.com/kisom/1698245
-(defn hash-str
+(defn hash-digest
   "Returns the hex digest of string. Defaults to SHA-256 hash."
-  ([input] (hash-str input "SHA-256"))
-  ([^java.lang.String input hash-algo]
-     (if (string? input)
-       (let [md (MessageDigest/getInstance hash-algo)]
-         (.update md (.getBytes input))
-         (let [digest (.digest md)]
-           (apply str (map #(format "%02x" (bit-and % 0xff)) digest))))
-       (do
-         (println "Invalid input to hexdigst! Expected string, got" (type input))
-         nil))))
+  ([input] (hash-digest input "SHA-256"))
+  ([input hash-algo]
+   (let [md (doto (MessageDigest/getInstance hash-algo)
+              (.update (.getBytes input)))]
+     (apply str (map #(format "%02x" (bit-and % 0xff)) (.digest md))))))
 
 (defn hash-file
   "Returns the sha256 digest of a file."
   [filename]
-  (when (.isFile (io/file filename))
-    (-> filename
-        (slurp)
-        (hash-str))))
+  (-> (io/file filename)
+      (slurp)
+      (hash-digest)))

--- a/src/triangulum/security.clj
+++ b/src/triangulum/security.clj
@@ -23,8 +23,3 @@
     (-> filename
         (slurp)
         (hash-str))))
-
-(defn compare-sha256
-  "Compare an object to a hash; true if (= (hash obj) ref-hash)."
-  [obj ref-hash]
-  (= ref-hash (hash-str obj "SHA-256")))

--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -41,7 +41,7 @@ WantedBy=default.target
           (log-str "out: "   out)
           (log-str "error: " err))))))
 
-(defn- enable-systemd [{:keys [repo user http https dir]}]
+(defn- enable-systemd [{:keys [repo http https dir]}]
   (let [service-name (str "cljweb-" repo)
         full-dir     (-> dir
                          (io/file)

--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -69,14 +69,13 @@ WantedBy=multi-user.target
    :extra-aliases ["-A" "--extra-aliases" "Setup server to run with extra aliases from deps.edn."]
    :http          ["-p" "--http HTTP" "Optional http port to run the server."]
    :https         ["-P" "--https HTTPS" "Optional https port to run the server."]
-   :repo          ["-r" "--repo REPO" "Repository folder that contains deps.edn.  This will be used to name the service"]
-   :user          ["-u" "--user USER" "The user account under which the service runs. An unprivileged user is recommended for security reasons."]})
+   :repo          ["-r" "--repo REPO" "Repository folder that contains deps.edn.  This will be used to name the service"]})
 
 (def ^:private cli-actions
   {:disable {:description "Disable systemd service."
              :requires    [:repo]}
    :enable  {:description "Enable systemd service. The service will be created if it doesn't exist."
-             :requires    [:repo :user]}
+             :requires    [:repo]}
    :restart {:description "Restart systemd service."
              :requires    [:repo]}
    :start   {:description "Start systemd service."

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -12,7 +12,7 @@
   (let [_ (gensym)]
     `(try ~@body (catch Exception ~_ nil))))
 
-;; Text parsing
+;;; Text parsing
 
 (defn kebab->snake
   "kebab-str -> snake_str"
@@ -65,7 +65,7 @@
     (subs s 0 (- (count s) (count end)))
     s))
 
-;; Response building
+;;; Response building
 
 (defn- clj->transit
   "Converts a clj body to transit."
@@ -100,7 +100,7 @@
                       :json    (json/write-str body)
                       body)})))
 
-;; Equivalent FP functions for maps
+;;; Equivalent FP functions for maps
 
 (defn mapm
   "Takes a map, applies f to each MapEntry, returns a map."
@@ -122,7 +122,7 @@
            (transient {})
            coll)))
 
-;; Equality checking
+;;; Equality checking
 
 (defn find-missing-keys
   "Returns true if m1's keys are a subset of m2's keys, and that any nested maps
@@ -145,7 +145,7 @@
     :else
     #{}))
 
-;; File operations
+;;; File operations
 
 (defn delete-recursively
   "Recursively deletes all files in `dir`.

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -5,6 +5,12 @@
             [clojure.set       :as set]
             [clojure.data.json :as json]))
 
+(defmacro nil-on-error
+  "Uses try to catch and return nil on error"
+  [& body]
+  (let [_ (gensym)]
+    `(try ~@body (catch Exception ~_ nil))))
+
 ;; Text parsing
 
 (defn kebab->snake

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -149,7 +149,7 @@
 
 (defn delete-recursively
   "Recursively deletes all files in `dir`.
-  (Reference)[https://gist.github.com/edw/5128978]"
+  [Reference](https://gist.github.com/edw/5128978)"
   [dir]
   (let [func (fn [func f]
                (when (.isDirectory f)

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -147,13 +147,5 @@
 
 ;;; File operations
 
-(defn delete-recursively
-  "Recursively deletes all files in `dir`.
-  [Reference](https://gist.github.com/edw/5128978)"
-  [dir]
-  (let [func (fn [func f]
-               (when (.isDirectory f)
-                 (doseq [f2 (.listFiles f)]
-                   (func func f2)))
-               (io/delete-file f))]
-    (func func (io/file dir))))
+(defn delete-recursively [dir]
+  (run! io/delete-file (reverse (file-seq (io/file dir)))))

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -1,11 +1,12 @@
 (ns triangulum.utils
   (:import java.io.ByteArrayOutputStream)
-  (:require [babashka.process   :refer [shell]]
-            [clojure.data.json  :as json]
+  (:require [clojure.data.json  :as json]
             [clojure.set        :as set]
             [clojure.string     :as str]
             [cognitect.transit  :as transit]
-            [triangulum.logging :refer [log]]))
+            [triangulum.logging :refer [log]]
+            [clojure.java.io    :as io]
+            [babashka.process   :refer [shell]]))
 
 ;;; Text parsing
 

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -1,12 +1,12 @@
 (ns triangulum.utils
   (:import java.io.ByteArrayOutputStream)
-  (:require [clojure.data.json  :as json]
+  (:require [babashka.process   :refer [shell]]
+            [clojure.data.json  :as json]
+            [clojure.java.io    :as io]
             [clojure.set        :as set]
             [clojure.string     :as str]
             [cognitect.transit  :as transit]
-            [triangulum.logging :refer [log]]
-            [clojure.java.io    :as io]
-            [babashka.process   :refer [shell]]))
+            [triangulum.logging :refer [log]]))
 
 ;;; Text parsing
 

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -244,5 +244,7 @@
 
 ;;; File operations
 
-(defn delete-recursively [dir]
+(defn delete-recursively
+  "Recursively delete all files and directories under the given directory."
+  [dir]
   (run! io/delete-file (reverse (file-seq (io/file dir)))))

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -1,8 +1,9 @@
 (ns triangulum.utils
   (:import java.io.ByteArrayOutputStream)
   (:require [cognitect.transit :as transit]
-            [clojure.string    :as str]
+            [clojure.java.io   :as io]
             [clojure.set       :as set]
+            [clojure.string    :as str]
             [clojure.data.json :as json]))
 
 (defmacro nil-on-error
@@ -143,3 +144,16 @@
 
     :else
     #{}))
+
+;; File operations
+
+(defn delete-recursively
+  "Recursively deletes all files in `dir`.
+  (Reference)[https://gist.github.com/edw/5128978]"
+  [dir]
+  (let [func (fn [func f]
+               (when (.isDirectory f)
+                 (doseq [f2 (.listFiles f)]
+                   (func func f2)))
+               (io/delete-file f))]
+    (func func (io/file dir))))

--- a/test/triangulum/cli_test.clj
+++ b/test/triangulum/cli_test.clj
@@ -16,7 +16,7 @@
           :default  "small"
           :validate [#{"big" "medium" "small"} "Must be \"big\", \"medium\", or \"small\""]]})
 
-(deftest test-cli-options
+(deftest ^:unit test-cli-options
   (let [defaults {:int 1 :str "test" :flag false :set "small"}
         sut      (fn [args config]
                    (get-cli-options (concat ["run-test"] args) cli-options cli-actions "run-test" config))]

--- a/test/triangulum/config_test.clj
+++ b/test/triangulum/config_test.clj
@@ -19,7 +19,7 @@
 
 (use-fixtures :each load-test-config)
 
-(deftest get-config-test
+(deftest ^:unit get-config-test
   (testing "Get config for single value."
     (is (= "testing" (get-config :mode))))
 

--- a/test/triangulum/core_test.clj
+++ b/test/triangulum/core_test.clj
@@ -6,6 +6,6 @@
             [triangulum.logging]
             [triangulum.utils]))
 
-(deftest workflow-test
+(deftest ^:unit workflow-test
   (testing "A simple test"
     (is (= 2 (+ 1 1)))))

--- a/test/triangulum/migrate_test.clj
+++ b/test/triangulum/migrate_test.clj
@@ -3,7 +3,7 @@
             [clojure.java.io      :as io]
             [next.jdbc            :as jdbc]
             [next.jdbc.result-set :refer [as-unqualified-lower-maps]]
-            [triangulum.security  :refer [hash-str]]
+            [triangulum.security  :refer [hash-digest]]
             [triangulum.migrate   :refer [migrate!] :as m]
             [triangulum.utils     :refer [delete-recursively]]))
 
@@ -87,7 +87,7 @@
         (let [migrations (get-migrations con)]
           (is (pos? (count migrations)))
           (is (= (-> migrations first :filename) filename))
-          (is (= (-> migrations first :hash) (hash-str contents)))))))
+          (is (= (-> migrations first :hash) (hash-digest contents)))))))
 
   (testing "Migrations are not run more than once."
     ; Arrange

--- a/test/triangulum/migrate_test.clj
+++ b/test/triangulum/migrate_test.clj
@@ -13,6 +13,7 @@
 
 ;; Helpers
 (defn- get-conn [database user user-pass]
+  (println "Attempting to connect to" database user user-pass)
   (jdbc/get-connection {:dbtype                "postgresql"
                         :dbname                database
                         :user                  user

--- a/test/triangulum/migrate_test.clj
+++ b/test/triangulum/migrate_test.clj
@@ -30,7 +30,7 @@
                         :reWriteBatchedInserts true}))
 
 (defn- get-admin-conn []
-  (get-conn "postgres"
+  (get-conn (or (System/getenv "PGDATABASE") "postgres")
             (or (System/getenv "PGUSER") "postgres")
             (or (System/getenv "PGPASSWORD") "")))
 

--- a/test/triangulum/migrate_test.clj
+++ b/test/triangulum/migrate_test.clj
@@ -22,7 +22,7 @@
 
 (defn- get-admin-conn []
   (get-conn (or (System/getenv "PGDATABASE") "postgres")
-            (or (System/getenv "PGUSER") "postgres")
+            (or (System/getenv "PGUSERNAME") "postgres")
             (or (System/getenv "PGPASSWORD") "")))
 
 (defn- get-migrations [db-conn]

--- a/test/triangulum/migrate_test.clj
+++ b/test/triangulum/migrate_test.clj
@@ -1,0 +1,138 @@
+(ns triangulum.migrate-test
+  (:require [clojure.test         :refer [is deftest testing use-fixtures run-tests]]
+            [clojure.java.io      :as io]
+            [next.jdbc            :as jdbc]
+            [next.jdbc.result-set :refer [as-unqualified-lower-maps]]
+            [triangulum.security  :refer [hash-str]]
+            [triangulum.migrate   :refer [migrate!] :as m]))
+
+;; Debugging
+(def ^:private verbose? false)
+(def ^:private tri-test "tri_test")
+
+;; Helpers
+(defn delete-recursively
+  "Recursively deletes all files in `dir`.
+  (Reference)[https://gist.github.com/edw/5128978]"
+  [dir]
+  (let [func (fn [func f]
+               (when (.isDirectory f)
+                 (doseq [f2 (.listFiles f)]
+                   (func func f2)))
+               (clojure.java.io/delete-file f))]
+    (func func (clojure.java.io/file dir))))
+
+(defn- get-conn [database user user-pass]
+  (jdbc/get-connection {:dbtype                "postgresql"
+                        :dbname                database
+                        :user                  user
+                        :password              user-pass
+                        :reWriteBatchedInserts true}))
+
+(defn- get-admin-conn []
+  (get-conn "postgres"
+            (or (System/getenv "PGUSER") "postgres")
+            (or (System/getenv "PGPASSWORD") "")))
+
+(defn- get-migrations [db-conn]
+  (jdbc/execute! db-conn
+                 ["SELECT * FROM tri.migrations;"]
+                 {:builder-fn as-unqualified-lower-maps}))
+
+;; Fixtures
+(defn- set-migrations-dir [f]
+  (when (.exists (io/file "tmp")) (delete-recursively "tmp"))
+  (with-bindings {#'m/*migrations-dir* "tmp/sql/changes/"}
+    (f))
+  (delete-recursively "tmp"))
+
+(def ^:private create-db ["CREATE ROLE tri_test WITH LOGIN CREATEDB PASSWORD 'tri_test';"
+                          "CREATE DATABASE tri_test WITH OWNER tri_test;"])
+(def ^:private drop-db   ["DROP DATABASE IF EXISTS tri_test;" "DROP ROLE IF EXISTS tri_test"])
+
+(defn- setup-test-db [f]
+  (with-open [con (get-admin-conn)]
+    (doseq [q (concat drop-db create-db)]
+      (jdbc/execute-one! con [q])))
+  (f)
+  (with-open [con (get-admin-conn)]
+    (doseq [q drop-db]
+      (jdbc/execute-one! con [q]))))
+
+(use-fixtures :once setup-test-db set-migrations-dir)
+
+(deftest ^:db migrate-test
+  (testing "No migrations, sets up the 'tri.migrations' table"
+    ; Arrange
+
+    ; Act
+    (migrate! tri-test tri-test tri-test verbose?)
+
+    ; Assert
+    (with-open [con (get-conn tri-test tri-test tri-test)]
+      (is (some? (jdbc/execute-one! con ["SELECT * FROM pg_catalog.pg_tables
+                                         WHERE schemaname = 'tri'
+                                         AND tablename = 'migrations';"])))))
+
+  (testing "Completed migration is stored in the 'tri.migrations' table"
+    ; Arrange
+    (let [filename "01-create-users-table.sql"
+          contents "CREATE TABLE users (id SERIAL PRIMARY KEY, username VARCHAR, password VARCHAR);"]
+
+      (io/make-parents (str m/*migrations-dir* filename))
+      (spit (str m/*migrations-dir* filename) contents)
+
+      ; Act
+      (migrate! tri-test tri-test tri-test verbose?)
+
+      ; Assert
+      (with-open [con (get-conn tri-test tri-test tri-test)]
+        (let [migrations (get-migrations con)]
+          (is (pos? (count migrations)))
+          (is (= (-> migrations first :filename) filename))
+          (is (= (-> migrations first :hash) (hash-str contents)))))))
+
+  (testing "Migrations are not run more than once."
+    ; Arrange
+    (spit (str m/*migrations-dir* "02-add-column-city-users.sql")
+          "ALTER TABLE users ADD COLUMN city VARCHAR;")
+
+    ; Act
+    (doseq [_ (range 0 5)]
+      (migrate! tri-test tri-test tri-test verbose?))
+
+    ; Assert
+    (with-open [con (get-conn tri-test tri-test tri-test)]
+      (let [migrations (get-migrations con)]
+        (is (= (count migrations) 2)))
+      (let [columns (jdbc/execute! con ["SELECT column_name FROM information_schema.columns
+                                        WHERE table_schema = 'public'
+                                        AND table_name = 'users'"])]
+        (is (= (count columns) 4)))))
+
+  (testing "Migrations do not continue once an error has been reached."
+    ; Arrange
+    (spit (str m/*migrations-dir* "03-ERROR.sql")
+          "ALTER TABLE users ADD state;")
+
+    (spit (str m/*migrations-dir* "04-add-table-pets.sql")
+          "CREATE TABLE pets ( id SERIAL PRIMARY KEY, pet_name VARCHAR);")
+
+    ; Act
+    (is (thrown? Exception (migrate! tri-test tri-test tri-test verbose?)))
+
+    ; Assert
+    (with-open [con (get-conn tri-test tri-test tri-test)]
+      (let [migrations (get-migrations con)
+            columns    (jdbc/execute! con ["SELECT column_name FROM information_schema.columns
+                                           WHERE table_schema = 'public'
+                                           AND table_name = 'users'"])]
+        (is (= (count migrations) 2))
+        (is (= (count columns) 4)))))
+
+  (testing "Errors out when a migration is modified."
+    ; Arrange
+    (spit (str m/*migrations-dir* "01-create-users-table.sql") "CREATE TABLE users (id SERIAL PRIMARY KEY);")
+
+    ; Act/Assert
+    (is (thrown? Exception (migrate! tri-test tri-test tri-test false)))))

--- a/test/triangulum/migrate_test.clj
+++ b/test/triangulum/migrate_test.clj
@@ -1,27 +1,17 @@
 (ns triangulum.migrate-test
-  (:require [clojure.test         :refer [is deftest testing use-fixtures run-tests]]
+  (:require [clojure.test         :refer [is deftest testing use-fixtures]]
             [clojure.java.io      :as io]
             [next.jdbc            :as jdbc]
             [next.jdbc.result-set :refer [as-unqualified-lower-maps]]
             [triangulum.security  :refer [hash-str]]
-            [triangulum.migrate   :refer [migrate!] :as m]))
+            [triangulum.migrate   :refer [migrate!] :as m]
+            [triangulum.utils     :refer [delete-recursively]]))
 
 ;; Debugging
 (def ^:private verbose? false)
 (def ^:private tri-test "tri_test")
 
 ;; Helpers
-(defn delete-recursively
-  "Recursively deletes all files in `dir`.
-  (Reference)[https://gist.github.com/edw/5128978]"
-  [dir]
-  (let [func (fn [func f]
-               (when (.isDirectory f)
-                 (doseq [f2 (.listFiles f)]
-                   (func func f2)))
-               (clojure.java.io/delete-file f))]
-    (func func (clojure.java.io/file dir))))
-
 (defn- get-conn [database user user-pass]
   (jdbc/get-connection {:dbtype                "postgresql"
                         :dbname                database

--- a/test/triangulum/security_test.clj
+++ b/test/triangulum/security_test.clj
@@ -1,7 +1,7 @@
 (ns triangulum.security-test
   (:require [clojure.test        :refer [is deftest testing use-fixtures]]
             [clojure.java.io     :as io]
-            [triangulum.security :refer [hash-str hash-file]]
+            [triangulum.security :refer [hash-digest hash-file]]
             [triangulum.utils    :refer [delete-recursively]]))
 
 (defn- cleanup-tmp [f]
@@ -10,11 +10,11 @@
 
 (use-fixtures :each cleanup-tmp)
 
-(deftest ^:unit hash-str-test
+(deftest ^:unit hash-digest-test
   (testing "Performs a SHA-256 hash of a string."
-    (is (= (hash-str "clojure is great")
+    (is (= (hash-digest "clojure is great")
            "8cb3449c569eab427908cbdc57204c128ea7217f74124086e464498a26eb34a1"))
-    (is (= (hash-str "8cb3449c569eab427908cbdc57204c128ea7217f74124086e464498a26eb34a1")
+    (is (= (hash-digest "8cb3449c569eab427908cbdc57204c128ea7217f74124086e464498a26eb34a1")
            "8878dab7316b9de49c695a01ed00be02e3f9899889beebb466bd493cd4bc004e"))))
 
 (deftest ^:unit hash-file-test

--- a/test/triangulum/security_test.clj
+++ b/test/triangulum/security_test.clj
@@ -1,6 +1,6 @@
 (ns triangulum.security-test
-  (:require [clojure.test        :refer [is deftest testing use-fixtures]]
-            [clojure.java.io     :as io]
+  (:require [clojure.java.io     :as io]
+            [clojure.test        :refer [is deftest testing use-fixtures]]
             [triangulum.security :refer [hash-digest hash-file]]
             [triangulum.utils    :refer [delete-recursively]]))
 

--- a/test/triangulum/security_test.clj
+++ b/test/triangulum/security_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test        :refer [is deftest testing use-fixtures]]
             [clojure.java.io     :as io]
             [triangulum.security :refer [hash-str hash-file]]
-            [triangulum.utils     :refer [delete-recursively]]))
+            [triangulum.utils    :refer [delete-recursively]]))
 
 (defn- cleanup-tmp [f]
   (f)

--- a/test/triangulum/security_test.clj
+++ b/test/triangulum/security_test.clj
@@ -10,14 +10,14 @@
 
 (use-fixtures :each cleanup-tmp)
 
-(deftest hash-str-test
+(deftest ^:unit hash-str-test
   (testing "Performs a SHA-256 hash of a string."
     (is (= (hash-str "clojure is great")
            "8cb3449c569eab427908cbdc57204c128ea7217f74124086e464498a26eb34a1"))
     (is (= (hash-str "8cb3449c569eab427908cbdc57204c128ea7217f74124086e464498a26eb34a1")
            "8878dab7316b9de49c695a01ed00be02e3f9899889beebb466bd493cd4bc004e"))))
 
-(deftest hash-file-test
+(deftest ^:unit hash-file-test
   (testing "Performs a SHA-256 hash of a file."
     (let [tmp-file "tmp/test-sha.txt"]
 

--- a/test/triangulum/security_test.clj
+++ b/test/triangulum/security_test.clj
@@ -1,0 +1,19 @@
+(ns triangulum.security-test
+  (:require [clojure.test        :refer [is deftest testing]]
+            [triangulum.security :refer [hash-str hash-file compare-sha256]])
+  (:import [java.nio.file Files FileSystem Path]))
+
+(defn- tmp-file! ^Path [dir filename suffix]
+  (Files/createTempFile (FileSystem/getPath dir) filename suffix))
+
+(deftest hash-str-test
+  (testing "Performs a SHA-256 hash of a string."
+    (is (= (hash-str "clojure is great")
+           "8cb3449c569eab427908cbdc57204c128ea7217f74124086e464498a26eb34a1"))
+    (is (= (hash-str "8cb3449c569eab427908cbdc57204c128ea7217f74124086e464498a26eb34a1")
+           "8878dab7316b9de49c695a01ed00be02e3f9899889beebb466bd493cd4bc004e"))))
+
+(deftest hash-file-test
+  (testing "Performs a SHA-256 hash of a file."
+    (let [tmp (tmp-file! "/tmp" "test-sha" ".txt")]
+      (println tmp))))

--- a/test/triangulum/utils_test.clj
+++ b/test/triangulum/utils_test.clj
@@ -9,7 +9,7 @@
                                       mapm
                                       find-missing-keys]]))
 
-(deftest end-with-test
+(deftest ^:unit end-with-test
   (testing "Appends end-value when string doesn't end with end-value."
     (is (= (end-with "path" "/")
            "path/")))
@@ -18,22 +18,22 @@
     (is (= (end-with "path/" "/")
            "path/"))))
 
-(deftest format-str-test
+(deftest ^:unit format-str-test
   (testing "Allows any char after % to be used in formatting"
     (is (= (format-str "SELECT * FROM %1 WHERE %2 = %3" "table" "column" "'value'")
            "SELECT * FROM table WHERE column = 'value'"))))
 
-(deftest kebab->snake-test
+(deftest ^:unit kebab->snake-test
   (testing "Converts kebab-str to snake_str"
     (is (= (kebab->snake "my-string") "my_string"))
     (is (= (kebab->snake "MY-STRING") "MY_STRING"))))
 
-(deftest parse-as-sh-cmd-test
+(deftest ^:unit parse-as-sh-cmd-test
   (testing "Parses a string into a sh friendly array"
     (is (= (parse-as-sh-cmd "psql -p 5432 -U=username -W")
            ["psql" "-p" "5432" "-U=username" "-W"]))))
 
-(deftest data-response-test
+(deftest ^:unit data-response-test
   (testing "Defaults to status 200, body encoded as edn"
     (let [res (data-response {:message "Hello world"})]
       (is (= (:status res) 200))
@@ -60,12 +60,12 @@
     (is (= (mapm (fn [[k v]] [k (+ v 1)]) test-map)
            {:a 2 :b 3 :c 4 :d 5}))))
 
-(deftest filterm-test
+(deftest ^:unit filterm-test
   (testing "Filter map using pred, returns a map"
     (is (= (filterm (fn [[_ v]] (odd? v)) test-map)
            {:a 1 :c 3}))))
 
-(deftest find-missing-keys-test
+(deftest ^:unit find-missing-keys-test
   (testing "Two nested maps with same keys return empty set."
     (is (= #{}
            (find-missing-keys {:a "b" :c {:d "e"}} {:a "g" :c {:d "f"}}))))


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
TRI-7 is meant to add a automatic database migration command to Triangulum

This is necessary to make auto-deployment possible for projects with databases, as well as help to simplify the challenges with tracking which DB migrations have been run.

From the `triangulu.migrate/migrate!` docs:
> Performs the database migrations stored in the `src/sql/changes/` directory.
> Migrations must be stored in chronological order (e.g. `2021-02-28_add-users-table.sql`).
>
>Migrations run inside of a transaction block to ensure the entire migration is completed prior to being committed to the database.
>
>  Currently, this tool does not support rollbacks.
>
>  If a migration fails, all migrations which follow it will be cancelled.
>
>  Migrations which have been completed are stored in a table `tri.migrations`, and include a SHA-256 hash of the migration file contents. If a migration has  been altered, the migrations will fail. This is to ensure consistency as migrations  are added."

See tests for more examples.

## Related Issues
Closes TRI-7

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
Run `clj -M:test`
