### PR TITLE
Switch to user systemd services

### DIFF
--- a/README.org
+++ b/README.org
@@ -267,7 +267,7 @@ sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/custom.sh
 *** triangulum.systemd
 
 To make sure your application starts up on system reboot, you can use
-Triangulum to create a systemd ~.service~ file by adding the following to
+Triangulum to create a systemd user ~.service~ file by adding the following to
 your ~:aliases~ section in the ~deps.edn~ file:
 
 #+begin_src clojure
@@ -290,17 +290,21 @@ application's services are started:
 
 And then run:
 #+begin_src sh
-sudo clojure -M:systemd enable -r <REPO> -u <USER> [-p HTTP PORT] [-P HTTPS PORT] [-d REPO DIRECTORY]
+clojure -M:systemd enable -r <REPO> -u <USER> [-p HTTP PORT] [-P HTTPS PORT] [-d REPO DIRECTORY]
 #+end_src
 
 This will install a file named ~cljweb-<repo>.service~ into the
-~/etc/systemd/system/~ directory, reload the systemctl daemon, and have
-enabled your service. Now your service will be enabled at startup.  By default
-the current directory will be used in the service as the working directory.
-To supply an alternative, you can use ~-d~.  This will look for a clojure
-project in that directory.
+~/.config/systemd/user/~ directory, reload the systemctl daemon, and have
+enabled your service. By default the current directory will be used in the
+service as the working directory. To supply an alternative, you can use ~-d~.
+This will look for a clojure project in that directory.
 
-You can also start, stop, and restart your service with the following commands:
+To enable your user services to start on system reboot, you will need to run:
+#+begin_src sh
+sudo loginctl enable-linger "$USER"
+#+end_src
+
+Now your service will be enabled at startup.  You can also start, stop, and restart your service with the following commands:
 #+begin_src sh
 sudo clojure -M:systemd start -r <REPO>
 sudo clojure -M:systemd stop -r <REPO>

--- a/README.org
+++ b/README.org
@@ -306,9 +306,9 @@ sudo loginctl enable-linger "$USER"
 
 Now your service will be enabled at startup.  You can also start, stop, and restart your service with the following commands:
 #+begin_src sh
-sudo clojure -M:systemd start -r <REPO>
-sudo clojure -M:systemd stop -r <REPO>
-sudo clojure -M:systemd restart -r <REPO>
+clojure -M:systemd start -r <REPO>
+clojure -M:systemd stop -r <REPO>
+clojure -M:systemd restart -r <REPO>
 #+end_src
 
 ** Useful Development Aliases


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Switches the use of `systemd` to be run through the service user (e.g. `ceo`, `sig-app`). This allows us to avoid giving the service user `sudo` access, which would otherwise be needed in order to perform app restarts when updating the application.

Major changes:
* `systemctl` -> `systemctl --user`
* Removed `sudo` requirement
* Added README instructions on how to allow the user services to start on reboot.

## Related Issues
Closes OPS-41

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)
