### PR TITLE
Add a new sh-wrapper function

### DIFF
--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -63,9 +63,20 @@
 
 (def ^:private path-env (System/getenv "PATH"))
 
+(defn sh-exec-with
+  "Provides a given path and environment to one bash command,
+  and parses the output, creating an array as described in `parse-as-sh-cmd`.
+  Returns a map in the following format: {:exit 0 :out 'Output message\n' :err ''}"
+  [dir env command]
+  (sh/with-sh-dir dir
+    (sh/with-sh-env (merge {:PATH path-env} env)
+      (apply sh/sh (parse-as-sh-cmd command)))))
+
 (defn sh-wrapper
   "Provides a given path and environment to a set of bash commands,
-  and parses the output, creating an array as described in `parse-as-sh-cmd`."
+  and parses the output, creating an array as described in `parse-as-sh-cmd`.
+  Returns a string that combines all of the standard error (and optionally
+  the standard out when `verbose` is true) from running the set of commands."
   [dir env verbose & commands]
   (sh/with-sh-dir dir
     (sh/with-sh-env (merge {:PATH path-env} env)

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -66,7 +66,7 @@
 (defn sh-exec-with
   "Provides a path (`dir`) and environment (`env`) to one bash `command`
    and executes it. Returns a map in the following format:
-   {:exit 0 :out `Output message\n` :err ''}"
+   `{:exit 0 :out 'Output message\n' :err ''}`"
   [dir env command]
   (sh/with-sh-dir dir
     (sh/with-sh-env (merge {:PATH path-env} env)

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -64,25 +64,25 @@
 (def ^:private path-env (System/getenv "PATH"))
 
 (defn sh-exec-with
-  "Provides a given path and environment to one bash command,
-  and parses the output, creating an array as described in `parse-as-sh-cmd`.
-  Returns a map in the following format: {:exit 0 :out 'Output message\n' :err ''}"
+  "Provides a path (`dir`) and environment (`env`) to one bash `command`
+   and executes it. Returns a map in the following format:
+   {:exit 0 :out `Output message\n` :err ''}"
   [dir env command]
   (sh/with-sh-dir dir
     (sh/with-sh-env (merge {:PATH path-env} env)
       (apply sh/sh (parse-as-sh-cmd command)))))
 
 (defn sh-wrapper
-  "Provides a given path and environment to a set of bash commands,
-  and parses the output, creating an array as described in `parse-as-sh-cmd`.
-  Returns a string that combines all of the standard error (and optionally
-  the standard out when `verbose` is true) from running the set of commands."
-  [dir env verbose & commands]
+  "Provides a path and environment to a set of bash commands and parses
+   the output, creating an array as described in `parse-as-sh-cmd`.
+   Returns a string that combines all of the standard error (and optionally
+   the standard out when `verbose?` is true) from running the set of commands."
+  [dir env verbose? & commands]
   (sh/with-sh-dir dir
     (sh/with-sh-env (merge {:PATH path-env} env)
       (reduce (fn [acc cmd]
                 (let [{:keys [out err]} (apply sh/sh (parse-as-sh-cmd cmd))]
-                  (str acc (when verbose out) err)))
+                  (str acc (when verbose? out) err)))
               ""
               commands))))
 


### PR DESCRIPTION
## Purpose
Adding a new `sh-exec-with` function with the goal of returning a map containing the exit code, stdout, and stderr for only executing one command. Enhances the docstring for `sh-wrapper`


