### PR TITLE
Updating clojure/data.json version to work with BB

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps {com.cognitect/transit-clj {:mvn/version "1.0.324"}
         org.clojure/clojure       {:mvn/version "1.10.3"}
-        org.clojure/data.json     {:mvn/version "1.0.0"}
+        org.clojure/data.json     {:mvn/version "2.4.0"}
         org.clojure/tools.cli     {:mvn/version "1.0.206"}
         org.clojure/test.check    {:mvn/version "0.9.0"}
         org.postgresql/postgresql {:mvn/version "42.2.10"}


### PR DESCRIPTION
## Purpose
BB is not compatible with clojure/data.json version `1.0.0`. Updated it to `2.4.0`

## Submission Checklist
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
Importing triangulum.utils from a BB script should work without crashing and burning.
