### PR TITLE
Add back in current-year function

### DIFF
--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -1,5 +1,6 @@
 (ns triangulum.utils
-  (:import java.io.ByteArrayOutputStream)
+  (:import java.io.ByteArrayOutputStream
+           java.time.LocalDateTime)
   (:require [babashka.process   :refer [shell]]
             [clojure.data.json  :as json]
             [clojure.java.io    :as io]
@@ -248,3 +249,10 @@
   "Recursively delete all files and directories under the given directory."
   [dir]
   (run! io/delete-file (reverse (file-seq (io/file dir)))))
+
+;;; Miscellaneous
+
+(defn current-year
+  "Returns the current year as an integer."
+  []
+  (.getYear (LocalDateTime/now)))


### PR DESCRIPTION
## Purpose
Adds back in the `current-year` function that was removed in [this commit](https://github.com/sig-gis/triangulum/commit/6df46c1c57422116ed0ab467217f0b88592337ab#diff-743bd4dcf363eaada922b85dc60ee999d1acccdb8416d067ae6dbc1a77f9a1cc).

Runway depends on this function: https://gitlab.sig-gis.com/sig-gis/runway/-/blob/main/src/runway/cli.clj#L14:~:text=%5Btriangulum.utils%20%20%20%20%20%20%3Arefer%20%5Bcurrent%2Dyear%5D%5D


