### PR TITLE
systemd --user does not have access to multi-user.target

### DIFF
--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -25,7 +25,7 @@ Restart=always
 PrivateTmp=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 "))
 
 (defn- enable-systemd [{:keys [repo http https dir extra-aliases]}]


### PR DESCRIPTION
## Purpose

systemd does not have access to the `multi-user.target` when being run in `--user` mode.

https://unix.stackexchange.com/questions/666509/systemd-service-does-not-start-wantedby-multi-user-target

https://unix.stackexchange.com/questions/506347/why-do-most-systemd-examples-contain-wantedby-multi-user-target

## Related Issues
Closes PLAN-183

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given..., When ..., Then ....

## Screenshots
<!-- Add a screen shot when UI changes are included -->

