### PR TITLE
COL-481: Add request keys to spec

### DIFF
--- a/config.namespaced-example.edn
+++ b/config.namespaced-example.edn
@@ -13,8 +13,10 @@
  :triangulum.server/keystore-password "foobar"
 
  ;; handler (server)
- :triangulum.handler/session-key      "changeme12345678" ; must be 16 characters
- :triangulum.handler/bad-tokens       #{".php"}
+ :triangulum.handler/session-key           "changeme12345678" ; must be 16 characters
+ :triangulum.handler/bad-tokens            #{".php"}
+ :triangulum.handler/private-request-keys  #{:base64Image :plotFileBase64 :sampleFileBase64}
+ :triangulum.handler/private-response-keys #{}
 
  ;; workers (server)
  :triangulum.worker/workers           [{:triangulum.worker/name  "scheduler"

--- a/config.namespaced-example.edn
+++ b/config.namespaced-example.edn
@@ -19,65 +19,65 @@
  :triangulum.handler/private-response-keys #{}
 
  ;; workers (server)
- :triangulum.worker/workers           [{:triangulum.worker/name  "scheduler"
-                                        :triangulum.worker/start product-ns.jobs/start-scheduled-jobs!
-                                        :triangulum.worker/stop  product-ns.jobs/stop-scheduled-jobs!}]
+ :triangulum.worker/workers [{:triangulum.worker/name  "scheduler"
+                              :triangulum.worker/start product-ns.jobs/start-scheduled-jobs!
+                              :triangulum.worker/stop  product-ns.jobs/stop-scheduled-jobs!}]
 
  ;; response (server)
- :triangulum.response/response-type   :json ; :edn or :transit
+ :triangulum.response/response-type :json ; :edn or :transit
 
  ;; views (app)
- :triangulum.views/title              {:en "Product name in English"
-                                       :es "Product name in Spanish"}
- :triangulum.views/description        {:en "Description of the product in English"
-                                       :es "Description of the product in Spanish"}
- :triangulum.views/keywords           {:en "english keywords, satellite imagery, collection, monitoring, fire"
-                                       :es "spanish keywords, satellite imagery, collection, monitoring, fire"}
- :triangulum.views/extra-head-tags    [[:meta {:name "viewport" :content "width=device-width, user-scalable=no"}]
-                                       [:link {:rel "manifest" :href "/favicon/site.webmanifest"}]
-                                       [:link {:rel "shortcut icon" :href "/favicon/favicon.ico"}]]
- :triangulum.views/gtag-id            "G-..."
- :triangulum.views/static-css-files   ["/css/my_global.css"]      ; in resources/public/
- :triangulum.views/static-js-files    ["/js/jquery-3.4.1.min.js"] ; in resources/public/
- :triangulum.views/get-user-lang      product-ns.api/get-user-lang
- :triangulum.views/js-init            "/src/js/main.jsx"     ; for Javascript projects
- :triangulum.views/cljs-init          product-ns.client.init ; for ClojureScript projects
- :triangulum.views/client-keys        {:mapbox-token "token123"}
+ :triangulum.views/title            {:en "Product name in English"
+                                     :es "Product name in Spanish"}
+ :triangulum.views/description      {:en "Description of the product in English"
+                                     :es "Description of the product in Spanish"}
+ :triangulum.views/keywords         {:en "english keywords, satellite imagery, collection, monitoring, fire"
+                                     :es "spanish keywords, satellite imagery, collection, monitoring, fire"}
+ :triangulum.views/extra-head-tags  [[:meta {:name "viewport" :content "width=device-width, user-scalable=no"}]
+                                     [:link {:rel "manifest" :href "/favicon/site.webmanifest"}]
+                                     [:link {:rel "shortcut icon" :href "/favicon/favicon.ico"}]]
+ :triangulum.views/gtag-id          "G-..."
+ :triangulum.views/static-css-files ["/css/my_global.css"]      ; in resources/public/
+ :triangulum.views/static-js-files  ["/js/jquery-3.4.1.min.js"] ; in resources/public/
+ :triangulum.views/get-user-lang    product-ns.api/get-user-lang
+ :triangulum.views/js-init          "/src/js/main.jsx"     ; for Javascript projects
+ :triangulum.views/cljs-init        product-ns.client.init ; for ClojureScript projects
+ :triangulum.views/client-keys      {:mapbox-token "token123"}
 
  ;; git (app)
- :triangulum.git/tags-url             "https://gitlab.sig-gis.com/api/v4/projects/<PROJECT_ID>/repository/tags"
+ :triangulum.git/tags-url "https://gitlab.sig-gis.com/api/v4/projects/<PROJECT_ID>/repository/tags"
 
  ;; database (database)
- :triangulum.database/host            "localhost"
- :triangulum.database/port            5432
- :triangulum.database/dbname          "app-name"
- :triangulum.database/user            "app-name"
- :triangulum.database/password        "app-name"
+ :triangulum.database/host     "localhost"
+ :triangulum.database/port     5432
+ :triangulum.database/dbname   "app-name"
+ :triangulum.database/user     "app-name"
+ :triangulum.database/password "app-name"
 
  ;; build-db (database)
- :triangulum.build-db/admin-pass      "postgres-password"
- :triangulum.build-db/dev-data        false
- :triangulum.build-db/file            "db-backup.custom"
- :triangulum.build-db/verbose         true
+ :triangulum.build-db/admin-pass "postgres-password"
+ :triangulum.build-db/dev-data   false
+ :triangulum.build-db/file       "db-backup.custom"
+ :triangulum.build-db/verbose    true
 
  ;; email (mail)
- :triangulum.email/host               "smtp.gmail.com"
- :triangulum.email/user               ""
- :triangulum.email/pass               ""
- :triangulum.email/tls                true
- :triangulum.email/port               587
- :triangulum.email/base-url           "https://my.domain/"
+ :triangulum.email/host     "smtp.gmail.com"
+ :triangulum.email/user     ""
+ :triangulum.email/pass     ""
+ :triangulum.email/tls      true
+ :triangulum.email/port     587
+ :triangulum.email/base-url "https://my.domain/"
 
  ;; https (https)
- :triangulum.https/email              "support@sig-gis.com"
- :triangulum.https/domain             "app.sig-gis.com"
- :triangulum.https/path               "/etc/letsencrypt"
- :triangulum.https/cert-only          false
- :triangulum.https/webroot            "./resources/public"
+ :triangulum.https/email     "support@sig-gis.com"
+ :triangulum.https/domain    "app.sig-gis.com"
+ :triangulum.https/path      "/etc/letsencrypt"
+ :triangulum.https/cert-only false
+ :triangulum.https/webroot   "./resources/public"
 
  ;; product-ns (my-keys)
- :product-ns.py-interop/ee-account    "product-ns@earth-engine-product-ns.iam.gserviceaccount.com"
- :product-ns.py-interop/ee-key-path   "gee-auth-key.json"
- :product-ns.views/mapbox-token       "pk..."
- :product-ns.views/mapquest-key       "GF..."
- :product-ns.proxy/nicfi-key          "e5..."}
+ :product-ns.py-interop/ee-account  "product-ns@earth-engine-product-ns.iam.gserviceaccount.com"
+ :product-ns.py-interop/ee-key-path "gee-auth-key.json"
+ :product-ns.views/mapbox-token     "pk..."
+ :product-ns.views/mapquest-key     "GF..."
+ :product-ns.proxy/nicfi-key        "e5..."}

--- a/config.nested-example.edn
+++ b/config.nested-example.edn
@@ -11,6 +11,8 @@
             :keystore-file     "keystore.pkcs12"
             :keystore-type     "pkcs12"
             :keystore-password "foobar"
+            :private-request-keys  #{:base64Image :plotFileBase64 :sampleFileBase64}
+            :private-response-keys #{}
 
             ;; handler
             :session-key       "changeme12345678" ; must be 16 characters

--- a/config.nested-example.edn
+++ b/config.nested-example.edn
@@ -11,12 +11,12 @@
             :keystore-file     "keystore.pkcs12"
             :keystore-type     "pkcs12"
             :keystore-password "foobar"
-            :private-request-keys  #{:base64Image :plotFileBase64 :sampleFileBase64}
-            :private-response-keys #{}
 
             ;; handler
             :session-key       "changeme12345678" ; must be 16 characters
             :bad-tokens        #{".php"}
+            :private-request-keys  #{:base64Image :plotFileBase64 :sampleFileBase64}
+            :private-response-keys #{}
 
             ;; workers
             :workers           {:scheduler {:start product-ns.jobs/start-scheduled-jobs!

--- a/config.nested-example.edn
+++ b/config.nested-example.edn
@@ -1,85 +1,82 @@
 {:server   {;; server
-            :http-port         8080
-            :https-port        8443
-            :nrepl             false
-            :nrepl-port        5555
-            :nprel-bind        "127.0.0.1"
-            :cider-nrepl       true
-            :mode              "dev"
-            :log-dir           "logs"
-            :handler           product-ns.routing/handler
-            :keystore-file     "keystore.pkcs12"
-            :keystore-type     "pkcs12"
-            :keystore-password "foobar"
+            :http-port             8080
+            :https-port            8443
+            :nrepl                 false
+            :nrepl-port            5555
+            :nprel-bind            "127.0.0.1"
+            :cider-nrepl           true
+            :mode                  "dev"
+            :log-dir               "logs"
+            :handler               product-ns.routing/handler
+            :keystore-file         "keystore.pkcs12"
+            :keystore-type         "pkcs12"
+            :keystore-password     "foobar"
 
             ;; handler
-            :session-key       "changeme12345678" ; must be 16 characters
-            :bad-tokens        #{".php"}
+            :session-key           "changeme12345678" ; must be 16 characters
+            :bad-tokens            #{".php"}
             :private-request-keys  #{:base64Image :plotFileBase64 :sampleFileBase64}
             :private-response-keys #{}
 
             ;; workers
-            :workers           {:scheduler {:start product-ns.jobs/start-scheduled-jobs!
-                                            :stop  product-ns.jobs/stop-scheduled-jobs!}}
+            :workers               {:scheduler {:start product-ns.jobs/start-scheduled-jobs!
+                                                :stop  product-ns.jobs/stop-scheduled-jobs!}}
 
             ;; response
-            :response-type     :json ; :edn or :transit
-            }
+            :response-type         :json} ; :edn or :transit
 
  :app      {;; views
-            :title             {:en "Product name in English"
-                                :es "Product name in Spanish"}
-            :description       {:en "Description of the product in English"
-                                :es "Description of the product in Spanish"}
-            :keywords          {:en "english keywords, satellite imagery, collection, monitoring, fire"
-                                :es "spanish keywords, satellite imagery, collection, monitoring, fire"}
-            :extra-head-tags   [[:meta {:name "viewport" :content "width=device-width, user-scalable=no"}]
-                                [:link {:rel "manifest" :href "/favicon/site.webmanifest"}]
-                                [:link {:rel "shortcut icon" :href "/favicon/favicon.ico"}]]
-            :gtag-id           "G-..."
-            :static-css-files  ["/css/my_global.css"]      ; in resources/public/
-            :static-js-files   ["/js/jquery-3.4.1.min.js"] ; in resources/public/
-            :get-user-lang     product-ns.api/get-user-lang
-            :js-init           "/src/js/main.jsx"     ; for Javascript projects
-            :cljs-init         product-ns.client.init ; for ClojureScript projects
-            :client-keys       {:mapbox-token "token123"}
+            :title            {:en "Product name in English"
+                               :es "Product name in Spanish"}
+            :description      {:en "Description of the product in English"
+                               :es "Description of the product in Spanish"}
+            :keywords         {:en "english keywords, satellite imagery, collection, monitoring, fire"
+                               :es "spanish keywords, satellite imagery, collection, monitoring, fire"}
+            :extra-head-tags  [[:meta {:name "viewport" :content "width=device-width, user-scalable=no"}]
+                               [:link {:rel "manifest" :href "/favicon/site.webmanifest"}]
+                               [:link {:rel "shortcut icon" :href "/favicon/favicon.ico"}]]
+            :gtag-id          "G-..."
+            :static-css-files ["/css/my_global.css"]      ; in resources/public/
+            :static-js-files  ["/js/jquery-3.4.1.min.js"] ; in resources/public/
+            :get-user-lang    product-ns.api/get-user-lang
+            :js-init          "/src/js/main.jsx"     ; for Javascript projects
+            :cljs-init        product-ns.client.init ; for ClojureScript projects
+            :client-keys      {:mapbox-token "token123"}
 
             ;; git
-            :tags-url          "https://gitlab.sig-gis.com/api/v4/projects/<PROJECT_ID>/repository/tags"}
-
-
+            :tags-url         "https://gitlab.sig-gis.com/api/v4/projects/<PROJECT_ID>/repository/tags"}
 
  :database {;; database
-            :host              "localhost"
-            :port              5432
-            :dbname            "app-name"
-            :user              "app-name"
-            :password          "app-name"
+            :host       "localhost"
+            :port       5432
+            :dbname     "app-name"
+            :user       "app-name"
+            :password   "app-name"
 
             ;; build-db
-            :admin-pass        "postgres-password"
-            :file              "db-backup.custom"
-            :dev-data          false
-            :verbose           true}
+            :admin-pass "postgres-password"
+            :file       "db-backup.custom"
+            :dev-data   false
+            :verbose    true}
 
  :mail     {;; email
-            :host              "smtp.gmail.com"
-            :user              ""
-            :pass              ""
-            :tls               true
-            :port              587
-            :base-url          "https://my.domain/"}
+            :host     "smtp.gmail.com"
+            :user     ""
+            :pass     ""
+            :tls      true
+            :port     587
+            :base-url "https://my.domain/"}
 
  :https    {;; https
-            :email             "support@sig-gis.com"
-            :domain            "app.sig-gis.com"
-            :path              "/etc/letsencrypt"
-            :cert-only         false
-            :webroot           "./resources/public"}
+            :email     "support@sig-gis.com"
+            :domain    "app.sig-gis.com"
+            :path      "/etc/letsencrypt"
+            :cert-only false
+            :webroot   "./resources/public"}
 
  :my-keys  {;; product-ns
-            :ee-account        "product-ns@earth-engine-product-ns.iam.gserviceaccount.com"
-            :ee-key-path       "gee-auth-key.json"
-            :mapbox-token      "pk..."
-            :mapquest-key      "GF..."
-            :nicfi-key         "e5..."}}
+            :ee-account   "product-ns@earth-engine-product-ns.iam.gserviceaccount.com"
+            :ee-key-path  "gee-auth-key.json"
+            :mapbox-token "pk..."
+            :mapquest-key "GF..."
+            :nicfi-key    "e5..."}}

--- a/src/triangulum/config_namespaced_spec.clj
+++ b/src/triangulum/config_namespaced_spec.clj
@@ -17,6 +17,8 @@
                                 :triangulum.server/keystore-file
                                 :triangulum.server/keystore-type
                                 :triangulum.server/keystore-password
+                                :triangulum.handler/private-request-keys
+                                :triangulum.handler/private-response-keys
                                 :triangulum.handler/bad-tokens
                                 :triangulum.worker/workers]))
 

--- a/src/triangulum/config_nested_spec.clj
+++ b/src/triangulum/config_nested_spec.clj
@@ -18,6 +18,8 @@
                                    :triangulum.server/keystore-type
                                    :triangulum.server/keystore-password
                                    :triangulum.handler/bad-tokens
+                                   :triangulum.handler/private-request-keys
+                                   :triangulum.handler/private-response-keys
                                    :triangulum.worker/workers]))
 
 (s/def ::app      (s/keys :opt-un [:triangulum.views/title


### PR DESCRIPTION
## Purpose
Specs to specify request and response keys to dissoc in the logging middleware.

## Related Issues
Complements COL-481 

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Define a set of request and response keys in the config file;
2. Run a server with triangulum;
3. When logging the request and response, the keys should not be included in the logs.

