### PR TITLE
TRIAN-98: Static files key can also contain urls

### DIFF
--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -21,6 +21,7 @@
 (s/def ::namespaced-symbol (s/and symbol? #(namespace %)))
 (s/def ::url               (s/and string? #(re-matches #"^https?://.+" %)))
 (s/def ::static-file-path  (s/and string? #(re-matches #"/[^:*?\"<>|]*" %)))
+(s/def ::url-or-file-path  (s/and string? #(re-matches #"^(https?:\/\/[^\s\/$.?#].[^\s]*)|(/[^:*?\"<>|]*)$" %)))
 (s/def ::path              (s/and string? #(re-matches #"[./][^:*?\"<>|]*" %)))
 (s/def ::hostname          (s/and string? #(re-matches #"[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}" %)))
 

--- a/src/triangulum/views.clj
+++ b/src/triangulum/views.clj
@@ -27,7 +27,7 @@
                                   :body  (s/? any?)))
 (s/def ::extra-head-tags   (s/coll-of ::hiccup-element :kind vector?))
 (s/def ::gtag-id           (s/and ::config/string #(str/starts-with? % "G-")))
-(s/def ::static-file-paths (s/coll-of ::config/static-file-path :kind vector?))
+(s/def ::static-file-paths (s/coll-of ::config/url-or-file-path :kind vector?))
 (s/def ::static-css-files  ::static-file-paths)
 (s/def ::static-js-files   ::static-file-paths)
 (s/def ::get-user-lang     ::config/namespaced-symbol)


### PR DESCRIPTION
## Purpose
Allow URLs to be used as static paths for js and css files. 

## Related Issues
Closes TRIAN-98

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. In the config file for a project, try passing a URL for either `static-js-files` or `static-css-files`.

