### PR TITLE
RAMI-67: Add database build extension to load and evaluate Puse library SQL folder.

### DIFF
--- a/src/triangulum/build_db.clj
+++ b/src/triangulum/build_db.clj
@@ -1,6 +1,7 @@
 (ns triangulum.build-db
   (:import java.io.File)
-  (:require [clojure.java.io    :as io]
+  (:require [clojure.java.classpath :as cp]
+            [clojure.java.io    :as io]
             [clojure.java.shell :as sh]
             [clojure.spec.alpha :as s]
             [clojure.string     :as str]
@@ -103,7 +104,12 @@
 (def ^:private folders {:tables    "./src/sql/tables"
                         :functions "./src/sql/functions"
                         :defaults  "./src/sql/default_data"
-                        :dev       "./src/sql/dev_data"})
+                        :dev       "./src/sql/dev_data"
+                        ;; Search the classpath for pulse sql folder, i.e. /somepath/pulse/src/sql
+                        :pulse     (->> (cp/classpath-directories)
+                                        (map #(.toString %))
+                                        (filter #(re-find #"pulse.*sql" %))
+                                        (first))})
 
 (defn- load-folder [sql-type host port database user user-pass verbose]
   (let [folder (sql-type folders)]
@@ -113,7 +119,7 @@
          (apply sh-wrapper "./" {:PGPASSWORD user-pass} verbose)
          (println))))
 
-(defn- build-everything [host port database user user-pass admin-pass dev-data? verbose]
+(defn- build-everything [host port database user user-pass admin-pass dev-data? pulse-data? verbose]
   (println "Building database...")
   (let [file (io/file "./src/sql/create_db.sql")]
     (if (.exists file)
@@ -129,7 +135,9 @@
           (load-folder :functions host port database user user-pass verbose)
           (load-folder :defaults host port database user user-pass verbose)
           (when dev-data?
-            (load-folder :dev host port database user user-pass verbose)))
+            (load-folder :dev host port database user user-pass verbose))
+          (when pulse-data?
+            (load-folder :pulse host port database user user-pass verbose)))
       (println "Error file ./src/sql/create_db.sql is missing."))))
 
 ;; Backup / restore functions
@@ -167,6 +175,7 @@
                 :default 5432]
    :dbname     ["-d"  "--dbname DB"            "Database name."]
    :dev-data   ["-x"  "--dev-data"             "Load dev data."]
+   :pulse-data ["-s"  "--pulse-data"           "Load pulse data."]
    :file       ["-f"  "--file FILE"            "File used for backup and restore."]
    :admin-pass ["-a"  "--admin-pass PASSWORD"  "Admin password for the postgres account."]
    :user       ["-u"  "--user USER"            "User for the database. Defaults to the same as the database name."]
@@ -193,7 +202,7 @@
                                                   cli-actions
                                                   "build-db"
                                                   (get-config :database))
-        {:keys [host port dbname dev-data file password admin-pass user verbose]} options]
+        {:keys [host port dbname dev-data pulse-data file password admin-pass user verbose]} options]
     (case action
       :build-all (build-everything host
                                    port
@@ -202,6 +211,7 @@
                                    (or password dbname) ; user-pass
                                    admin-pass
                                    dev-data
+                                   pulse-data
                                    verbose)
       :functions (load-folder :functions
                               host


### PR DESCRIPTION
## Purpose
Ticket RAMI-67 was created to explore a Triangulum extension that would add database build support to load SQL from a folder on the classpath. Functionality that is required to support loading the required database changes for the common change detection facilities of the **Pulse** library.

The change adds the  `--pulse-data` long cli flag. When specified as part of a database build, Triangulum will search the `classpath` for a pulse SQL folder,  then load and evaluate its contents.

This is, currently, a work in progress. Supporting changes to the top-sort's **"namespace"** resolution is needed.

## Related Issues
Closes [RAMI-67](https://sig-gis.atlassian.net/browse/RAMI-67)
