### PR TITLE
Fixes for CLJS webapps' cljs-init key

### DIFF
--- a/config.namespaced-example.edn
+++ b/config.namespaced-example.edn
@@ -44,7 +44,7 @@
  :triangulum.views/static-js-files  ["/js/jquery-3.4.1.min.js"] ; in resources/public/
  :triangulum.views/get-user-lang    product-ns.api/get-user-lang
  :triangulum.views/js-init          "/src/js/main.jsx"     ; for Javascript projects
- :triangulum.views/cljs-init        product-ns.client.init ; for ClojureScript projects
+ :triangulum.views/cljs-init        product-ns.client/init ; for ClojureScript projects
  :triangulum.views/client-keys      {:mapbox-token "token123"}
 
  ;; git (app)

--- a/config.nested-example.edn
+++ b/config.nested-example.edn
@@ -43,7 +43,7 @@
        :static-js-files  ["/js/jquery-3.4.1.min.js"] ; in resources/public/
        :get-user-lang    product-ns.api/get-user-lang
        :js-init          "/src/js/main.jsx"     ; for Javascript projects
-       :cljs-init        product-ns.client.init ; for ClojureScript projects
+       :cljs-init        product-ns.client/init ; for ClojureScript projects
        :client-keys      {:mapbox-token "token123"}
 
        ;; git

--- a/src/triangulum/handler.clj
+++ b/src/triangulum/handler.clj
@@ -161,8 +161,8 @@
   [n]
   (let [char-seq (map char (concat (range 48 58) ; 0-9
                                    (range 65 91) ; A-Z
-                                   (range 97 123) ; a-z
-                                   ))]
+                                   (range 97 123)))] ; a-z
+
     (apply str (take n (shuffle char-seq)))))
 
 (defn get-cookie-store

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -241,6 +241,14 @@
   (require (symbol (namespace sym)))
   (resolve sym))
 
+(defn clj-namespaced-symbol->js-module
+  "Given a namespace-qualified symbol, return its string representation as a JS module."
+  [sym]
+  (-> sym
+      (str)
+      (str/replace "/" ".")
+      (kebab->snake)))
+
 ;;; File operations
 
 (defn delete-recursively


### PR DESCRIPTION
## Purpose
Fixes the `:triangulum.views/cljs-init` key such that it works properly with CLJS webapps.

## Related Issues
HER-113

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)


