### PR TITLE
Simplify systemd tool with `babashka.fs`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src"]
 
- :deps {babashka/process                  {:mvn/version "0.5.21"}
+ :deps {babashka/fs                       {:mvn/version "0.5.20"}
+        babashka/process                  {:mvn/version "0.5.21"}
         bk/ring-gzip                      {:mvn/version "0.3.0"}
         cider/cider-nrepl                 {:mvn/version "0.30.0"}
         clj-http/clj-http                 {:mvn/version "3.12.3"}

--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -11,7 +11,6 @@
                                    :extra-env {"XDG_RUNTIME_DIR" xdg-runtime-dir}})
 (def ^:private user-systemctl          "systemctl --user")
 (def ^:private user-systemd-path       (path (fs/xdg-config-home) "systemd" "user"))
-(def ^:private systemd-multi-user-path (path user-systemd-path "multi-user.target.wants"))
 (def ^:private unit-file-template      (str/trim "
 [Unit]
 Description=A service to launch a server written in clojure
@@ -52,9 +51,7 @@ WantedBy=default.target
     (if (fs/exists? (io/file repo-dir "deps.edn"))
       (do
         (fs/create-dirs user-systemd-path)
-        (fs/create-dirs systemd-multi-user-path)
         (spit unit-file (fmt-service-file (merge config {:repo-dir repo-dir})))
-        (fs/create-sym-link (path systemd-multi-user-path service-file) unit-file)
         (shell-wrapper shell-opts user-systemctl "daemon-reload")
         (shell-wrapper shell-opts user-systemctl "enable" service-name))
       (println "The directory generated" repo-dir "does not contain a deps.edn file."))))

--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -29,7 +29,7 @@ Restart=always
 PrivateTmp=true
 
 [Install]
-WantedBy=default.target
+WantedBy=mulit-user.target.wants
 "))
 
 (defn fmt-service-file

--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -10,8 +10,8 @@
 (def ^:private shell-opts         {:dir       "/"
                                    :extra-env {"XDG_RUNTIME_DIR" xdg-runtime-dir}})
 (def ^:private user-systemctl          "systemctl --user")
-(def ^:private user-systemd-path       (path (fs/xdg-config-home) "systemd" "user"))
-(def ^:private unit-file-template      (str/trim "
+(def ^:private user-systemd-path  (path (fs/xdg-config-home) "systemd" "user"))
+(def ^:private unit-file-template (str/trim "
 [Unit]
 Description=A service to launch a server written in clojure
 After=network.target

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -256,6 +256,14 @@
   [dir]
   (run! io/delete-file (reverse (file-seq (io/file dir)))))
 
+(defn path
+  "Takes variadic args and returns a path string. Args can be any type that can be coerced via `str`.
+
+  Example:
+  `(path (io/file \"my-dir\") \"file.csv\") ; => \"my-dir/file.csv\" (on Unix) "
+  [& args]
+  (str (apply io/file (map str args))))
+
 ;;; Miscellaneous
 
 (defn current-year

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -11,6 +11,11 @@
 
 ;;; Text parsing
 
+(defn snake->kebab
+  "Converts snake_str to kebab-str."
+  [snake_str]
+  (str/replace snake_str "_" "-"))
+
 (defn kebab->snake
   "Converts kebab-str to snake_str."
   [kebab-str]
@@ -38,6 +43,21 @@
   "Use any char after % for format. All % are converted to %s (string)."
   [f-str & args]
   (apply format (str/replace f-str #"(%[^ ])" "%s") args))
+
+(defn format-with-dict
+  "Replaces `fmt-str` with values from `m`.
+
+   NOTE: `fmt-str` must use handlebars (`{{<keyword>}}`) wherever a term is to be replaced.
+
+   Example:
+   ```
+   (format-with-dict \"Hi {{name}}! The moon is {{n}} billion years old.\" {:name \"Bob\" :n 4.5}) ; => \"Hi Bob! The moon is 4.5 billion years old.\" 
+   ```"
+  [fmt-str m]
+  (let [handlebar #"\{\{([^\}]+)\}\}"
+        fmt-keys (re-seq handlebar fmt-str)
+        values   (map #(get m (-> % (second) (snake->kebab) (keyword)) "") fmt-keys)]
+    (apply format (str/replace fmt-str handlebar "%s") values)))
 
 (defn parse-as-sh-cmd
   "Split string into an array for use with clojure.java.shell/sh."


### PR DESCRIPTION
## Purpose
- Adds `triangulum.utils/path` to make it easier to generate path strings
- Adds `babashka.fs` as a library for Triangulum to feel more Clojure-y
- Replaces a few Java fns with the `fs/*` equivalent
- Uses babashka.fs to symlink `cljweb-<repo-name>.service` to
`multi-user.target.wants` dir