### PR TITLE
fixups after babashka migration and new parsing template

### DIFF
--- a/src/triangulum/systemd.clj
+++ b/src/triangulum/systemd.clj
@@ -57,6 +57,7 @@ WantedBy=mulit-user.target.wants
         full-dir     (-> dir
                          (fs/expand-home)
                          (fs/absolutize)
+                         (str)
                          (remove-end "."))
         repo-dir     (if (= (fs/file-name full-dir) repo)
                        full-dir

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -57,7 +57,7 @@
   (let [handlebar #"\{\{([^\}]+)\}\}"
         fmt-keys  (re-seq handlebar fmt-str)
         m         (update-vals m (fnil identity ""))
-        values    (map #(m (-> % (second) (snake->kebab) (keyword))) fmt-keys)]
+        values    (map #(get m (-> % (second) (snake->kebab) (keyword)) "") fmt-keys)]
     (apply format (str/replace fmt-str handlebar "%s") values)))
 
 (defn parse-as-sh-cmd
@@ -294,6 +294,7 @@
 
 (comment
   (format-with-dict "hi {{x}} world" {:x nil})
+  (format-with-dict "hi {{x}} world" {})
   (format-with-dict "hi {{x}} world" {:x false})
   (format-with-dict "hi {{x}} world" {:x 42})
   (format-with-dict "hi {{x}} world" {:x "nice"}))

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -55,9 +55,9 @@
    ```"
   [fmt-str m]
   (let [handlebar #"\{\{([^\}]+)\}\}"
-        fmt-keys (re-seq handlebar fmt-str)
-        m (update-vals m (fnil identity ""))
-        values (map #(m (-> % (second) (snake->kebab) (keyword))) fmt-keys)]
+        fmt-keys  (re-seq handlebar fmt-str)
+        m         (update-vals m (fnil identity ""))
+        values    (map #(m (-> % (second) (snake->kebab) (keyword))) fmt-keys)]
     (apply format (str/replace fmt-str handlebar "%s") values)))
 
 (defn parse-as-sh-cmd

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -56,7 +56,8 @@
   [fmt-str m]
   (let [handlebar #"\{\{([^\}]+)\}\}"
         fmt-keys (re-seq handlebar fmt-str)
-        values   (map #(get m (-> % (second) (snake->kebab) (keyword)) "") fmt-keys)]
+        m (update-vals m (fnil identity ""))
+        values (map #(m (-> % (second) (snake->kebab) (keyword))) fmt-keys)]
     (apply format (str/replace fmt-str handlebar "%s") values)))
 
 (defn parse-as-sh-cmd
@@ -290,3 +291,10 @@
   "Returns the current year as an integer."
   []
   (.getYear (LocalDateTime/now)))
+
+(comment
+  (format-with-dict "hi {{x}} world" {:x nil})
+  (format-with-dict "hi {{x}} world" {:x false})
+  (format-with-dict "hi {{x}} world" {:x 42})
+  (format-with-dict "hi {{x}} world" {:x "nice"}))
+

--- a/src/triangulum/utils.clj
+++ b/src/triangulum/utils.clj
@@ -291,11 +291,3 @@
   "Returns the current year as an integer."
   []
   (.getYear (LocalDateTime/now)))
-
-(comment
-  (format-with-dict "hi {{x}} world" {:x nil})
-  (format-with-dict "hi {{x}} world" {})
-  (format-with-dict "hi {{x}} world" {:x false})
-  (format-with-dict "hi {{x}} world" {:x 42})
-  (format-with-dict "hi {{x}} world" {:x "nice"}))
-

--- a/test/triangulum/utils_test.clj
+++ b/test/triangulum/utils_test.clj
@@ -4,6 +4,7 @@
                                       #_{:clj-kondo/ignore [:deprecated-var]}
                                       data-response
                                       format-str
+                                      format-with-dict
                                       kebab->snake
                                       filterm
                                       parse-as-sh-cmd
@@ -81,3 +82,13 @@
     (is (= #{:d :e :f :g :i}
            (find-missing-keys {:a "b" :c {:d "e"} :e {:f "f" :g "g"} :h {:i "i"}}
                               {:a "g" :c {:y "z"} :h nil})))))
+
+(deftest ^:unit format-with-dict-test
+  (testing "nil"
+    (is (= "hi," (format-with-dict "hi,{{x}}" {:x nil}))))
+  (testing "absence"
+    (is (= "hi," (format-with-dict "hi,{{x}}" {}))))
+  (testing "presence"
+    (is (= "hi,false" (format-with-dict "hi,{{x}}" {:x false})))
+    (is (= "hi,42" (format-with-dict "hi,{{x}}" {:x 42})))
+    (is  (= "hi,nice" (format-with-dict "hi,{{x}}" {:x "nice"})))))


### PR DESCRIPTION
## Issues
1. Using the new template with the `{{x}}` format causes parsing strings to erroneous getting replaced by `null` instead of `""` when "absent"
2. Java exception thrown while trying to parse java.nio.file.Path as a string in triangulum.utils/remove-end fn

## Fixes
1. Coerce nils to ""
2. transform the `Path` into a `String` before calling `remove-end`