### PR TITLE
Longer request logging

### DIFF
--- a/src/triangulum/handler.clj
+++ b/src/triangulum/handler.clj
@@ -87,7 +87,7 @@
     (let [{:keys [uri request-method params]} request
           private-request-keys                (or (get-config :server :private-request-keys)
                                                   #{:password :passwordConfirmation})
-          param-str                           (binding [*print-length* -1] (pr-str (apply dissoc params private-request-keys)))]
+          param-str                           (binding [*print-length* -1] (print-str (apply dissoc params private-request-keys)))]
       (log-str "Request(" (name request-method) "): \"" uri "\" " param-str)
       (handler request))))
 

--- a/src/triangulum/handler.clj
+++ b/src/triangulum/handler.clj
@@ -87,7 +87,7 @@
     (let [{:keys [uri request-method params]} request
           private-request-keys                (or (get-config :server :private-request-keys)
                                                   #{:password :passwordConfirmation})
-          param-str                           (binding [*print-length -1] (pr-str (apply dissoc params private-request-keys)))]
+          param-str                           (binding [*print-length* -1] (pr-str (apply dissoc params private-request-keys)))]
       (log-str "Request(" (name request-method) "): \"" uri "\" " param-str)
       (handler request))))
 

--- a/src/triangulum/handler.clj
+++ b/src/triangulum/handler.clj
@@ -87,7 +87,7 @@
     (let [{:keys [uri request-method params]} request
           private-request-keys                (or (get-config :server :private-request-keys)
                                                   #{:password :passwordConfirmation})
-          param-str                           (pr-str (apply dissoc params private-request-keys))]
+          param-str                           (binding [*print-length -1] (pr-str (apply dissoc params private-request-keys)))]
       (log-str "Request(" (name request-method) "): \"" uri "\" " param-str)
       (handler request))))
 

--- a/src/triangulum/logging.clj
+++ b/src/triangulum/logging.clj
@@ -38,7 +38,7 @@
            :or {newline? true pprint? false force-stdout? false truncate? true}}]
   (let [timestamp    (.format (SimpleDateFormat. "MM/dd HH:mm:ss") (Date.))
         log-filename (str (.format (SimpleDateFormat. "YYYY-MM-dd") (Date.)) ".log")
-        max-data     (if truncate? (max-length data 500) data)
+        max-data     (if truncate? (max-length data 2000) data)
         line         (str timestamp
                           " "
                           (if pprint? (with-out-str (pp/pprint data)) max-data)


### PR DESCRIPTION
## Purpose
Added a longer character limit to logging to help with debugging requests that come through Triangulum. The logs would unhelpfully cut off before showing all of the details of input arguments, which made understanding the JSON request as it came through rather difficult.

## Related Issues
Closes [HER-648](https://sig-gis.atlassian.net/browse/HER-648)

## Submission Checklist
- [x] Commits include the JIRA issue
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Screenshots
![Screenshot from 2024-08-26 11-21-21](https://github.com/user-attachments/assets/e5fc153f-2173-45d9-9b04-78dc9691300f)




[HER-648]: https://sig-gis.atlassian.net/browse/HER-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ