### PR TITLE
Truncate request config

### DIFF
--- a/README.org
+++ b/README.org
@@ -67,6 +67,7 @@ file logging system, and worker functions for non-HTTP-related tasks.
                :cider-nrepl       true      ; If your editor supports CIDER middleware
                :mode              "dev"     ; or prod
                :log-dir           "logs"    ; or "" for stdout
+               :truncate-request? false     ; true by default
                :handler           product-ns.routing/handler
                :workers           {:scheduler {:start product-ns.jobs/start-scheduled-jobs!
                                                :stop  product-ns.jobs/stop-scheduled-jobs!}}

--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -24,6 +24,7 @@
 (s/def ::url-or-file-path  (s/and string? #(re-matches #"^(https?:\/\/[^\s\/$.?#].[^\s]*)|(/[^:*?\"<>|]*)$" %)))
 (s/def ::path              (s/and string? #(re-matches #"[./][^:*?\"<>|]*" %)))
 (s/def ::hostname          (s/and string? #(re-matches #"[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}" %)))
+(s/def ::boolean           boolean?)
 
 ;; Config file
 

--- a/src/triangulum/handler.clj
+++ b/src/triangulum/handler.clj
@@ -23,7 +23,7 @@
                                                         wrap-frame-options
                                                         wrap-xss-protection]]
             [triangulum.config                  :as config :refer [get-config]]
-            [triangulum.logging                 :refer [log-str]]
+            [triangulum.logging                 :refer [log log-str]]
             [triangulum.errors                  :refer [nil-on-error]]
             [triangulum.utils                   :refer [resolve-foreign-symbol]]
             [triangulum.response                :refer [forbidden-response data-response]]))
@@ -87,8 +87,11 @@
     (let [{:keys [uri request-method params]} request
           private-request-keys                (or (get-config :server :private-request-keys)
                                                   #{:password :passwordConfirmation})
+          truncate-request?                   (if (some? (get-config :server :truncate-request?))
+                                                (get-config :server :truncate-request?)
+                                                true)
           param-str                           (pr-str (apply dissoc params private-request-keys))]
-      (log-str "Request(" (name request-method) "): \"" uri "\" " param-str)
+      (log (apply str "Request(" (name request-method) "): \"" uri "\" " param-str) :truncate? truncate-request?)
       (handler request))))
 
 (defn wrap-response-logging

--- a/src/triangulum/logging.clj
+++ b/src/triangulum/logging.clj
@@ -33,7 +33,7 @@
   "Synchronously create a log entry. Logs will got to standard out as default.
    A log file location can be specified with set-log-path!.
 
-   Default options are {:newline? true :pprint? false :force-stdout? false}"
+   Default options are {:newline? true :pprint? false :force-stdout? false truncate? true}"
   [data & {:keys [newline? pprint? force-stdout? truncate?]
            :or {newline? true pprint? false force-stdout? false truncate? true}}]
   (let [timestamp    (.format (SimpleDateFormat. "MM/dd HH:mm:ss") (Date.))

--- a/src/triangulum/server.clj
+++ b/src/triangulum/server.clj
@@ -25,6 +25,7 @@
 (s/def ::cider-nrepl       boolean?)
 (s/def ::mode              (s/and ::config/string #{"dev" "prod"}))
 (s/def ::log-dir           ::config/string)
+(s/def ::truncate-request? ::config/boolean)
 (s/def ::handler           ::config/namespaced-symbol)
 (s/def ::keystore-file     ::config/string)
 (s/def ::keystore-type     ::config/string)
@@ -44,13 +45,14 @@
 (defn start-server!
   "See README.org -> Web Framework -> triangulum.server for details."
   [{:keys [http-port https-port nrepl cider-nrepl nrepl-bind nrepl-port mode log-dir
-           handler workers keystore-file keystore-type keystore-password]
+           truncate-request? handler workers keystore-file keystore-type keystore-password]
     :or   {nrepl-bind        "127.0.0.1"
            nrepl-port        5555
            keystore-file     "./.key/keystore.pkcs12"
            keystore-type     "pkcs12"
            keystore-password "foobar"
            log-dir           ""
+           truncate-request? true
            mode              "prod"}}]
   (let [has-key?      (and keystore-file (.exists (io/file keystore-file)))
         ssl?          (and has-key? https-port)
@@ -59,7 +61,8 @@
                           (create-handler-stack ssl? reload?))
         config        (merge
                        {:port  http-port
-                        :join? false}
+                        :join? false
+                        :truncate-request? truncate-request?}
                        (when ssl?
                          {:ssl?             true
                           :ssl-port         https-port


### PR DESCRIPTION
## Purpose
Added a configurable flag to toggle the character limit in logging. This should help with debugging requests that come through Triangulum. The logs would unhelpfully cut off before showing all of the details of input arguments, which made understanding JSON requests as they came through rather difficult.

This flag keeps the default behavior of :truncate? for requests to be true, even if the key is missing from config.edn.

## Related Issues
Closes [HER-648](https://sig-gis.atlassian.net/browse/HER-648)

## Submission Checklist
- [x] Commits include the JIRA issue
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Screenshots
![Screenshot from 2024-08-26 11-21-21](https://github.com/user-attachments/assets/e5fc153f-2173-45d9-9b04-78dc9691300f)




[HER-648]: https://sig-gis.atlassian.net/browse/HER-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

