### PR TITLE
Removing :truncate-request? from server config

### DIFF
--- a/README.org
+++ b/README.org
@@ -67,7 +67,7 @@ file logging system, and worker functions for non-HTTP-related tasks.
                :cider-nrepl       true      ; If your editor supports CIDER middleware
                :mode              "dev"     ; or prod
                :log-dir           "logs"    ; or "" for stdout
-               :truncate-request? false     ; true by default
+               :truncate-request  true      ; false by default
                :handler           product-ns.routing/handler
                :workers           {:scheduler {:start product-ns.jobs/start-scheduled-jobs!
                                                :stop  product-ns.jobs/stop-scheduled-jobs!}}

--- a/config.namespaced-example.edn
+++ b/config.namespaced-example.edn
@@ -18,6 +18,7 @@
  :triangulum.handler/route-authenticator   product-ns.handlers/route-authenticator
  :triangulum.handler/routing-tables        [backend-libary-ns.routing/routes product-ns.routing/routes]
  :triangulum.handler/bad-tokens            #{".php"}
+ :triangulum.handler/truncate-request      false
  :triangulum.handler/private-request-keys  #{:base64Image :plotFileBase64 :sampleFileBase64}
  :triangulum.handler/private-response-keys #{}
 

--- a/config.nested-example.edn
+++ b/config.nested-example.edn
@@ -18,6 +18,7 @@
           :route-authenticator   product-ns.handlers/route-authenticator
           :routing-tables        [common-libary-ns.routing/routes product-ns.routing/routes]
           :bad-tokens            #{".php"}
+          :truncate-request      false
           :private-request-keys  #{:base64Image :plotFileBase64 :sampleFileBase64}
           :private-response-keys #{}
 

--- a/src/triangulum/config.clj
+++ b/src/triangulum/config.clj
@@ -24,7 +24,6 @@
 (s/def ::url-or-file-path  (s/and string? #(re-matches #"^(https?:\/\/[^\s\/$.?#].[^\s]*)|(/[^:*?\"<>|]*)$" %)))
 (s/def ::path              (s/and string? #(re-matches #"[./][^:*?\"<>|]*" %)))
 (s/def ::hostname          (s/and string? #(re-matches #"[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}" %)))
-(s/def ::boolean           boolean?)
 
 ;; Config file
 

--- a/src/triangulum/config_namespaced_spec.clj
+++ b/src/triangulum/config_namespaced_spec.clj
@@ -33,6 +33,7 @@
                                :triangulum.handler/redirect-handler
                                :triangulum.handler/route-authenticator
                                :triangulum.handler/routing-tables
+                               :triangulum.handler/truncate-request
                                :triangulum.handler/private-request-keys
                                :triangulum.handler/private-response-keys
                                :triangulum.handler/bad-tokens

--- a/src/triangulum/config_nested_spec.clj
+++ b/src/triangulum/config_nested_spec.clj
@@ -20,6 +20,7 @@
                                    :triangulum.handler/route-authenticator
                                    :triangulum.handler/routing-tables
                                    :triangulum.handler/bad-tokens
+                                   :triangulum.handler/truncate-request
                                    :triangulum.handler/private-request-keys
                                    :triangulum.handler/private-response-keys
                                    :triangulum.worker/workers

--- a/src/triangulum/handler.clj
+++ b/src/triangulum/handler.clj
@@ -35,6 +35,7 @@
 (s/def ::route-authenticator   ::config/namespaced-symbol)
 (s/def ::routing-tables        (s/coll-of ::config/namespaced-symbol))
 (s/def ::bad-tokens            (s/coll-of ::config/string :kind set? :min-count 0))
+(s/def ::truncate-request      boolean?)
 (s/def ::private-request-keys  (s/coll-of keyword :kind set?))
 (s/def ::private-response-keys (s/coll-of keyword :kind set?))
 
@@ -85,11 +86,9 @@
   [handler]
   (fn [request]
     (let [{:keys [uri request-method params]} request
+          truncate-request?                   (get-config :server :truncate-request)
           private-request-keys                (or (get-config :server :private-request-keys)
                                                   #{:password :passwordConfirmation})
-          truncate-request?                   (if (some? (get-config :server :truncate-request?))
-                                                (get-config :server :truncate-request?)
-                                                true)
           param-str                           (pr-str (apply dissoc params private-request-keys))]
       (log (apply str "Request(" (name request-method) "): \"" uri "\" " param-str) :truncate? truncate-request?)
       (handler request))))

--- a/src/triangulum/server.clj
+++ b/src/triangulum/server.clj
@@ -25,7 +25,6 @@
 (s/def ::cider-nrepl       boolean?)
 (s/def ::mode              (s/and ::config/string #{"dev" "prod"}))
 (s/def ::log-dir           ::config/string)
-(s/def ::truncate-request? ::config/boolean)
 (s/def ::handler           ::config/namespaced-symbol)
 (s/def ::keystore-file     ::config/string)
 (s/def ::keystore-type     ::config/string)

--- a/src/triangulum/server.clj
+++ b/src/triangulum/server.clj
@@ -61,8 +61,7 @@
                           (create-handler-stack ssl? reload?))
         config        (merge
                        {:port  http-port
-                        :join? false
-                        :truncate-request? truncate-request?}
+                        :join? false}
                        (when ssl?
                          {:ssl?             true
                           :ssl-port         https-port

--- a/src/triangulum/server.clj
+++ b/src/triangulum/server.clj
@@ -45,14 +45,13 @@
 (defn start-server!
   "See README.org -> Web Framework -> triangulum.server for details."
   [{:keys [http-port https-port nrepl cider-nrepl nrepl-bind nrepl-port mode log-dir
-           truncate-request? handler workers keystore-file keystore-type keystore-password]
+           handler workers keystore-file keystore-type keystore-password]
     :or   {nrepl-bind        "127.0.0.1"
            nrepl-port        5555
            keystore-file     "./.key/keystore.pkcs12"
            keystore-type     "pkcs12"
            keystore-password "foobar"
            log-dir           ""
-           truncate-request? true
            mode              "prod"}}]
   (let [has-key?      (and keystore-file (.exists (io/file keystore-file)))
         ssl?          (and has-key? https-port)


### PR DESCRIPTION
It's automatically being added without needing an explicit key to be set.

## Submission Checklist
- [x] Code passes linter rules (`clj-kondo --lint src`)