### PR TITLE
TRIAN-112 GSR-69  Extend maximum payload size to handle large csv data sets

### DIFF
--- a/config.namespaced-example.edn
+++ b/config.namespaced-example.edn
@@ -21,6 +21,8 @@
  :triangulum.handler/truncate-request      false
  :triangulum.handler/private-request-keys  #{:base64Image :plotFileBase64 :sampleFileBase64}
  :triangulum.handler/private-response-keys #{}
+ :triangulum.handler/upload-max-size-mb    100
+ :triangulum.handler/upload-max-file-count 10
 
  ;; workers (server)
  :triangulum.worker/workers [{:triangulum.worker/name  "scheduler"

--- a/config.nested-example.edn
+++ b/config.nested-example.edn
@@ -21,6 +21,8 @@
           :truncate-request      false
           :private-request-keys  #{:base64Image :plotFileBase64 :sampleFileBase64}
           :private-response-keys #{}
+          :upload-max-size-mb    100
+          :upload-max-file-count 10
 
           ;; workers
           :workers {:scheduler {:start product-ns.jobs/start-scheduled-jobs!

--- a/src/triangulum/config_namespaced_spec.clj
+++ b/src/triangulum/config_namespaced_spec.clj
@@ -18,7 +18,7 @@
                  #(no-keys-of-ns? % "triangulum.server")
                  :server-keys
                  (s/keys :req [:triangulum.server/http-port
-                               :triangulum.server/handler]
+                              :triangulum.server/handler]
                          :opt [:triangulum.server/https-port
                                :triangulum.server/nrepl
                                :triangulum.server/nrepl-port
@@ -37,6 +37,8 @@
                                :triangulum.handler/private-request-keys
                                :triangulum.handler/private-response-keys
                                :triangulum.handler/bad-tokens
+                               :triangulum.handler/upload-max-size-mb
+                               :triangulum.handler/upload-max-file-count
                                :triangulum.worker/workers
                                :triangulum.response/response-type])))
 

--- a/src/triangulum/config_namespaced_spec.clj
+++ b/src/triangulum/config_namespaced_spec.clj
@@ -18,7 +18,7 @@
                  #(no-keys-of-ns? % "triangulum.server")
                  :server-keys
                  (s/keys :req [:triangulum.server/http-port
-                              :triangulum.server/handler]
+                               :triangulum.server/handler]
                          :opt [:triangulum.server/https-port
                                :triangulum.server/nrepl
                                :triangulum.server/nrepl-port

--- a/src/triangulum/config_nested_spec.clj
+++ b/src/triangulum/config_nested_spec.clj
@@ -23,6 +23,8 @@
                                    :triangulum.handler/truncate-request
                                    :triangulum.handler/private-request-keys
                                    :triangulum.handler/private-response-keys
+                                   :triangulum.handler/upload-max-size-mb
+                                   :triangulum.handler/upload-max-file-count
                                    :triangulum.worker/workers
                                    :triangulum.response/response-type]))
 


### PR DESCRIPTION
## Purpose

Added configurable upload limits and progress tracking. Fixes 413 errors for large GSR policy file uploads. By default, handles files up to 100MB with progress updates.

## Related Issues
TRI-112 GSR-69

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing
 Try uploading the sample portfolio CSV into GSR prod server
- Log in with an Admin account
- Click the Admin button on the upper right corner of the homepage
- Click the Select CSV File button under Upload CSV File
- Use the attached csv file: 
- Click Upload
