### PR TITLE
Move sql files into the classpath to support java-jar-ification

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,6 +18,12 @@ A Clojure library that provides:
                        :git/sha "REPLACE-WITH-CURRENT-SHA"}
    #+end_src
 
+   Add src/sql to your deps.edn paths:
+
+   #+begin_src clojure
+   :paths ["src/sql"]
+   #+end_src
+
    If you want to pull Triangulum into a [[https://babashka.org][Babashka]] script, you can do
    so with ~babashka.deps~ as follows:
 
@@ -246,6 +252,12 @@ This tag label will be passed to the browser code in the ~:session~ map under th
 **** Required Prerequisites
 
 - [[https://www.postgresql.org/download][Postgresql (version 12)]]
+
+Add src/sql to your deps.edn paths:
+
+   #+begin_src clojure
+   :paths ["src/sql"]
+   #+end_src
 
 To set up the folder and file structure for use with ~build-db~, use the following directory structure:
 


### PR DESCRIPTION
## Purpose

The sql files are moved onto the classpath by saving their resource-paths at compile time. Then, because, as previously designed, they need to be passed to psql's file reader (-f), the sql resources are written back out to temporary files, which are deleted when the JVM exits.


## Related Issues
PYR1-1084

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review`. - it's part of PYR1-1084 but it wouldn't close it
- [x] Code passes linter rules (`clj-konode passes linter rules (`clj-kondo --lint src`)

## Testing
Include src/sql on the paths and then run the build-db commands as normal. They will now additionally work 
if those commands are passed to a jar.



