### PR TITLE
Add manifest.edn to classpath, so it can be accessed inside a jar.

### DIFF
--- a/src/triangulum/views.clj
+++ b/src/triangulum/views.clj
@@ -38,7 +38,7 @@
 (defn- find-cljs-app-js
   "Returns the relative path of the compiled ClojureScript app.js file."
   []
-  (as-> (slurp "target/public/cljs/manifest.edn") app
+  (as-> (slurp (io/resource "public/cljs/manifest.edn")) app
     (edn/read-string app)
     (get app "target/public/cljs/app.js")
     (str/split app #"/")


### PR DESCRIPTION
## Purpose

This allows any app using Triangulum, that servers up an app.js, to be included in a jar as long as it puts "target" on it's
deps.edn paths.

The change, as all jar supporting changes would be, is about changing it so a file that's accessed at runtime on the filepath, is instead a resource that is accessible on the  classpath (inside the jar).

In this case, that file is the manfiest.edn which is read at runtime on every Pyregence http request as part of triangulum.views/render-page. Here it is in https://github.com/pyregence/pyregence/blob/ca39bb36079dbcce6b6a34653650b36b0b7e8478/src/clj/pyregence/routing.clj#L13:

```
[:get "/"]                   {:handler (render-page "/")}
```

Here is the call tree that ends with render-page and starts with find-cljs-app-js:
```
▾   find-cljs-app-js triangulum/views
 ▾   head  triangulum.views
  ▸   render-page  triangulum.views
```
And as you can see below, triangulum.views/find-cljs-app-js needs to be updated to look on the classpath, as well as shed the target part of the path:

```
-  (as-> (slurp "target/public/cljs/manifest.edn") app
+  (as-> (slurp (io/resource "public/cljs/manifest.edn")) app
```

## Dependent PR

This PR works with this one on Pyregence: https://github.com/pyregence/pyregence/pull/933

## Other PR considerations..

Note that the build-db changes are part of this PR. Those are being tracked here https://github.com/sig-gis/triangulum/pull/146/files

## Related Issues
PYR1-1084, PYR1-1083

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

## Testing

Testing this is best done from Pyregence. From this Pyregence commit: 8130d0a8bd87e1e739ad1b8aaa6982e285c59ed7 /
branch: https://github.com/pyregence/pyregence/tree/support-running-server-from-a-jar
PR: https://github.com/pyregence/pyregence/pull/933

They point at this commit on GitHub (which we can update when it gets folded into main). With that branch checked out, build a jar:

```
clj -X:uberjar
```

To test the jar, it's best to move it out of the directory, so that any file system functions won't fool you into thinking the jar works. Just make sure you move your config.edn as well:

```
java -jar pyregence-2025.04.14-8130d0a8-standalone.jar server start
```



