### PR TITLE
Update docs to mention adding target to paths.

### DIFF
--- a/README.org
+++ b/README.org
@@ -186,13 +186,11 @@ generating HTML, and handling various types of responses.
 
 **** Prerequisites
 
-Add "target" to your deps.edn paths:
+Add ~"target"~ to your ~deps.edn~ ~:paths~ so that Triangulum can find the file ~target/public/cljs/app.js~:
 
 #+begin_src clojure
-:paths ["target"]
+:paths ["target"] ;; Include other necessary paths.
 #+end_src
-
-So Triangulum can find target/public/cljs/app.js.
 
 **** Usage
 

--- a/README.org
+++ b/README.org
@@ -193,7 +193,7 @@ Add "target" to your deps.edn paths:
 :paths ["target"]
 #+end_src
 
-So Triangulum can find your app.js.
+So Triangulum can find target/public/cljs/app.js.
 
 **** Usage
 

--- a/README.org
+++ b/README.org
@@ -184,6 +184,17 @@ This namespace provides functions for rendering pages and handling
 resources in Triangulum. It defines functions for reading asset files,
 generating HTML, and handling various types of responses.
 
+**** Prerequisites
+
+
+Add "target" to your deps.edn paths:
+
+#+begin_src clojure
+:paths ["target"]
+#+end_src
+
+So Triangulum can find your app.js.
+
 **** Usage
 
 1. Require the namespace in your project.

--- a/README.org
+++ b/README.org
@@ -186,7 +186,6 @@ generating HTML, and handling various types of responses.
 
 **** Prerequisites
 
-
 Add "target" to your deps.edn paths:
 
 #+begin_src clojure


### PR DESCRIPTION
## Purpose
To document the requirements on Triangulum application users imposed by an [earlier change. 
](https://github.com/sig-gis/triangulum/commit/03053626b4d15ec1363f64d39257e41e4e54463c)

Before that change, it was already a requirement that the app.js be built to /target/public/cljs/app.js, the change was to include target on the classpath so the app.js could be included in the jar.


## Related Issues
none

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)


