### PR TITLE
Set user var in load-folder

### DIFF
--- a/src/triangulum/build_db.clj
+++ b/src/triangulum/build_db.clj
@@ -136,7 +136,8 @@
   (let [resource-paths (get (sql-type->resource-path) sql-type)
         files          (map resource-path->tempfile! resource-paths)]
     (println (str "Loading " (name sql-type) "..."))
-    (->> (map #(format-str "psql -h %h -p %p -U %u -d %d -f %f" host port user database %)
+    (->> (map #(format-str "psql -h %h -p %p -U --set=user=%u %u -d %d -f %f"
+                           host port user user database %)
               files)
          (apply sh-wrapper "./" {:PGPASSWORD user-pass} verbose)
          (println))))

--- a/src/triangulum/build_db.clj
+++ b/src/triangulum/build_db.clj
@@ -136,7 +136,7 @@
   (let [resource-paths (get (sql-type->resource-path) sql-type)
         files          (map resource-path->tempfile! resource-paths)]
     (println (str "Loading " (name sql-type) "..."))
-    (->> (map #(format-str "psql -h %h -p %p -U --set=user=%u %u -d %d -f %f"
+    (->> (map #(format-str "psql -h %h -p %p --set=user=%u -U %u -d %d -f %f"
                            host port user user database %)
               files)
          (apply sh-wrapper "./" {:PGPASSWORD user-pass} verbose)


### PR DESCRIPTION
## Purpose
Set the `user` var in `load-folder` in order to dynamically be able to access it in `functions.sql` files.  

## Related Issues
Related to PYR1-1117

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `TRI-### #review <comment>`)
- [x] Code passes linter rules (`clj-kondo --lint src`)

