### PR TITLE
TRIAN-115: Allow JAR builds without config.edn

### DIFF
--- a/src/triangulum/handler.clj
+++ b/src/triangulum/handler.clj
@@ -251,12 +251,16 @@
       wrap-exceptions
       (optional-middleware wrap-reload reload?)))
 
-(def development-app
+(defonce ^:private handler
+  (delay (create-handler-stack
+          (fn [request]
+            (let [user-handler (-> (get-config :server :handler)
+                                   (resolve-foreign-symbol))]
+              (user-handler request)))
+          false
+          true)))
+
+(defn development-app
   "Handler function for development (figwheel)."
-  (create-handler-stack
-   (fn [request]
-     (let [user-handler (-> (get-config :server :handler)
-                            resolve-foreign-symbol)]
-       (user-handler request)))
-   false
-   true))
+  [request]
+  (@handler request))


### PR DESCRIPTION
## Purpose
Defer handler creation and config.edn loading to runtime

## Related Issues
Closes [TRIAN-115](https://sig-gis.atlassian.net/browse/TRIAN-115)

## Test 

`clojure -X:build-uberjar` without config.edn should work.



[TRIAN-115]: https://sig-gis.atlassian.net/browse/TRIAN-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ