### PR TITLE
PYR1-1242  Add key to allow From email address to be an alias

### DIFF
--- a/src/triangulum/email.clj
+++ b/src/triangulum/email.clj
@@ -32,14 +32,15 @@
 (defn- send-postal
   "Internal function to send emails via postal.
    Can optionally accept a custom email config map to override defaults."
-  ([to-addresses cc-addresses bcc-addresses subject body content-type] 
+  ([to-addresses cc-addresses bcc-addresses subject body content-type]
    (send-postal to-addresses cc-addresses bcc-addresses subject body content-type nil))
-  ([to-addresses cc-addresses bcc-addresses subject body content-type email-config] 
-   (let [config (or email-config
-                    (select-keys (get-config :mail) [:host :user :pass :tls :port]))
-         from-address (:user config)]
+  ([to-addresses cc-addresses bcc-addresses subject body content-type email-config]
+   (let [config       (or email-config
+                          (select-keys (get-config :mail) [:host :user :pass :tls :port :from]))
+         from-address (or (:from config) (:user config))
+         smtp-config  (dissoc config :from)]
      (send-message
-      config
+      smtp-config
       {:from    from-address
        :to      to-addresses
        :cc      cc-addresses


### PR DESCRIPTION
## Purpose

Support optional :from config to override email From address.

## Related Issues
Closes PYR1-1242

