### PR TITLE
PYR1-1556  Fix call-sql bigint arg overflow

### DIFF
--- a/src/triangulum/database.clj
+++ b/src/triangulum/database.clj
@@ -81,6 +81,16 @@
           :reWriteBatchedInserts true}
          (get-config :database)))
 
+(defn coerce-sql-arg
+  "Coerce a value to a JDBC-friendly type for a prepared-statement param. Int-range longs
+   narrow to int (for SQL `integer` params); out-of-range longs and doubles pass through so
+   they don't overflow; in-range doubles narrow to float."
+  [x]
+  (condp = (type x)
+    java.lang.Long   (if (<= Integer/MIN_VALUE x Integer/MAX_VALUE) (int x) x)
+    java.lang.Double (if (<= (- Float/MAX_VALUE) x Float/MAX_VALUE) (float x) x)
+    x))
+
 ;;; Select Queries
 
 (defn call-sql
@@ -102,11 +112,7 @@
                                     (str/join "," (map pr-str args)))]
     (when log? (log-str "SQL Call: " query-with-args))
     (jdbc/execute! (jdbc/get-datasource (pg-db))
-                   (into [query] (map #(condp = (type %)
-                                         java.lang.Long (int %)
-                                         java.lang.Double (float %)
-                                         %)
-                                      args))
+                   (into [query] (map coerce-sql-arg args))
                    {:builder-fn (if use-vec?
                                   rs/as-unqualified-lower-arrays
                                   rs/as-unqualified-lower-maps)})))

--- a/test/triangulum/database_test.clj
+++ b/test/triangulum/database_test.clj
@@ -1,0 +1,51 @@
+(ns triangulum.database-test
+  (:require [clojure.test        :refer [is deftest testing]]
+            [next.jdbc           :as jdbc]
+            [triangulum.config   :as config]
+            [triangulum.database :refer [call-sql coerce-sql-arg]]))
+
+;; coerce-sql-arg fixes the old "narrow every Long to int" path, which overflowed on bigint
+;; params like epoch-millisecond timestamps.
+
+(deftest ^:unit coerce-sql-arg-test
+  (testing "int-range longs are narrowed to Integer (SQL `integer` params)"
+    (is (instance? Integer (coerce-sql-arg 5)))
+    (is (= (int 5) (coerce-sql-arg 5)))
+    (is (instance? Integer (coerce-sql-arg -5)))
+    (is (instance? Integer (coerce-sql-arg (long Integer/MAX_VALUE))))
+    (is (instance? Integer (coerce-sql-arg (long Integer/MIN_VALUE)))))
+
+  (testing "out-of-range longs stay Long so bigint params don't overflow"
+    (is (instance? Long (coerce-sql-arg 1781208765120)))   ; the value that first hit the overflow
+    (is (= 1781208765120 (coerce-sql-arg 1781208765120)))
+    (is (instance? Long (coerce-sql-arg (inc (long Integer/MAX_VALUE)))))
+    (is (instance? Long (coerce-sql-arg (dec (long Integer/MIN_VALUE))))))
+
+  (testing "in-range doubles become floats; out-of-range doubles stay double"
+    (is (instance? Float  (coerce-sql-arg 3.14)))
+    (is (instance? Double (coerce-sql-arg 1.0E40)))   ; > Float/MAX_VALUE; narrowing would throw
+    (is (= 1.0E40 (coerce-sql-arg 1.0E40)))
+    (is (= "abc" (coerce-sql-arg "abc")))
+    (is (= :kw (coerce-sql-arg :kw)))
+    (is (nil? (coerce-sql-arg nil)))))
+
+(deftest ^:unit coerce-sql-arg-passthrough-test
+  (testing "numeric types other than Long/Double are left untouched"
+    (is (instance? Integer (coerce-sql-arg (int 7))))
+    (is (instance? Float   (coerce-sql-arg (float 1.5))))
+    (is (= 5N             (coerce-sql-arg 5N)))
+    (is (= 1.5M           (coerce-sql-arg 1.5M)))
+    (is (= (biginteger 9) (coerce-sql-arg (biginteger 9))))))
+
+;; call-sql itself must pass an out-of-range arg through as Long (jdbc stubbed, no DB).
+(deftest ^:unit call-sql-coerces-args-test
+  (testing "call-sql narrows int-range args but keeps bigint args as Long"
+    (let [captured (atom nil)]
+      (with-redefs [config/get-config   (fn [& _] {})   ; so pg-db needs no config.edn
+                    jdbc/get-datasource identity
+                    jdbc/execute!       (fn [_ params _] (reset! captured params) [])]
+        (call-sql "some_fn" {:log? false} 42 1781208765120))
+      (let [[_query small big] @captured]
+        (is (instance? Integer small))
+        (is (instance? Long big))
+        (is (= 1781208765120 big))))))


### PR DESCRIPTION
## Purpose

`call-sql` narrowed every integer argument to a 32-bit int before binding it, so a value
past about 2.1 billion (an epoch-millisecond timestamp, for example) threw an integer-overflow
error before it ever reached Postgres, even when the target column was a bigint.

It now narrows an integer only when it fits in 32 bits and leaves larger values as 64-bit longs,
which bind to bigint parameters correctly. In-range values are untouched, so existing callers
behave exactly as before. The same guard covers the double-to-float narrowing, which had the
matching overflow on very large doubles.

Adds unit tests for the coercion and for the `call-sql` wiring.