### PR TITLE
PYR1-1526 suppress Jetty Server header

### DIFF
--- a/README.org
+++ b/README.org
@@ -105,6 +105,7 @@ file logging system, and worker functions for non-HTTP-related tasks.
    - The ~:stop~ functions for all ~:workers~ will be run after the web server is stopped. They will receive the outputs of the ~:start~ functions.
    - Before starting the server, you must set ~:handler~ to a namespace-qualified symbol bound to a Ring handler function.
    - If you set ~:mode~ to "dev", then the ~wrap-reload~ middleware will be added to your handler function. This will automatically reload all of your namespaces into the running JVM on each HTTP request.
+   - The Jetty ~Server~ response header is suppressed (~:send-server-version? false~) so the Jetty version is not disclosed.
 
 *** triangulum.handler
 

--- a/src/triangulum/server.clj
+++ b/src/triangulum/server.clj
@@ -58,8 +58,9 @@
         handler-stack (-> (resolve-foreign-symbol handler)
                           (create-handler-stack ssl? reload?))
         config        (merge
-                       {:port  http-port
-                        :join? false}
+                       {:port                 http-port
+                        :join?                false
+                        :send-server-version? false}
                        (when ssl?
                          {:ssl?             true
                           :ssl-port         https-port

--- a/test/triangulum/server_test.clj
+++ b/test/triangulum/server_test.clj
@@ -1,0 +1,20 @@
+(ns triangulum.server-test
+  (:require [clojure.test       :refer [deftest is testing]]
+            [ring.adapter.jetty :as jetty]
+            [triangulum.handler :as handler]
+            [triangulum.logging :as logging]
+            [triangulum.notify  :as notify]
+            [triangulum.server  :refer [start-server!]]
+            [triangulum.utils   :as utils]))
+
+;; Side effects are stubbed so start-server! runs without starting a real server.
+(deftest ^:unit suppress-server-header-config-test
+  (testing "start-server! passes :send-server-version? false to run-jetty"
+    (let [captured (atom nil)]
+      (with-redefs [utils/resolve-foreign-symbol (constantly (fn [_] {:status 200}))
+                    handler/create-handler-stack (fn [& _] (fn [_] {:status 200}))
+                    jetty/run-jetty              (fn [_ config] (reset! captured config) nil) ; nil: leave the server atom clean
+                    logging/set-log-path!        (fn [& _] nil)
+                    notify/available?            (constantly false)]
+        (start-server! {:http-port 8080 :handler 'example/handler :mode "dev"}))
+      (is (false? (:send-server-version? @captured))))))


### PR DESCRIPTION
## Purpose

By default Jetty adds a `Server` header naming its version to every response, which reveals a bit
more about the server than we need to. This sets ring-jetty's built-in `:send-server-version? false`
so the header stays off. It's a single config option, so existing callers carry on unchanged and
responses are otherwise the same.

Adds a small test and a README note.