### PR TITLE
PYR1-1520 PYR1-1521 Opt-in Secure session cookies and HSTS

### DIFF
--- a/config.namespaced-example.edn
+++ b/config.namespaced-example.edn
@@ -23,6 +23,8 @@
  :triangulum.handler/private-response-keys #{}
  :triangulum.handler/upload-max-size-mb    100
  :triangulum.handler/upload-max-file-count 10
+ :triangulum.handler/session-cookie-attrs  {:secure true :same-site :lax}
+ :triangulum.handler/hsts?                 false
 
  ;; workers (server)
  :triangulum.worker/workers [{:triangulum.worker/name  "scheduler"

--- a/config.nested-example.edn
+++ b/config.nested-example.edn
@@ -23,6 +23,8 @@
           :private-response-keys #{}
           :upload-max-size-mb    100
           :upload-max-file-count 10
+          :session-cookie-attrs  {:secure true :same-site :lax}
+          :hsts?                 false
 
           ;; workers
           :workers {:scheduler {:start product-ns.jobs/start-scheduled-jobs!

--- a/src/triangulum/config_namespaced_spec.clj
+++ b/src/triangulum/config_namespaced_spec.clj
@@ -39,6 +39,8 @@
                                :triangulum.handler/bad-tokens
                                :triangulum.handler/upload-max-size-mb
                                :triangulum.handler/upload-max-file-count
+                               :triangulum.handler/session-cookie-attrs
+                               :triangulum.handler/hsts?
                                :triangulum.worker/workers
                                :triangulum.response/response-type])))
 

--- a/src/triangulum/config_nested_spec.clj
+++ b/src/triangulum/config_nested_spec.clj
@@ -25,6 +25,8 @@
                                    :triangulum.handler/private-response-keys
                                    :triangulum.handler/upload-max-size-mb
                                    :triangulum.handler/upload-max-file-count
+                                   :triangulum.handler/session-cookie-attrs
+                                   :triangulum.handler/hsts?
                                    :triangulum.worker/workers
                                    :triangulum.response/response-type]))
 

--- a/src/triangulum/handler.clj
+++ b/src/triangulum/handler.clj
@@ -18,7 +18,7 @@
             [ring.middleware.resource                   :refer [wrap-resource]]
             [ring.middleware.session                    :refer [wrap-session]]
             [ring.middleware.session.cookie             :refer [cookie-store]]
-            [ring.middleware.ssl                        :refer [wrap-ssl-redirect]]
+            [ring.middleware.ssl                        :refer [wrap-hsts wrap-ssl-redirect]]
             [ring.util.codec                            :refer [url-decode]]
             [ring.middleware.x-headers                  :refer [wrap-content-type-options
                                                                 wrap-frame-options
@@ -47,6 +47,12 @@
   ^{:doc "Maximum number of files allowed in a single upload request.
           Must be a positive integer not exceeding 100 files."}
   (s/and pos-int? #(<= % 100)))
+(s/def ::session-cookie-attrs
+  ^{:doc "Ring :cookie-attrs merged onto the session cookie, e.g. {:secure true :same-site :lax}."}
+  map?)
+(s/def ::hsts?
+  ^{:doc "Send an HSTS (Strict-Transport-Security) header when true; enable only over HTTPS. Default false."}
+  boolean?)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Routing Handler
@@ -227,29 +233,33 @@
 (defn create-handler-stack
   "Create the Ring handler stack."
   [routing-handler ssl? reload?]
-  (-> routing-handler
-      (optional-middleware wrap-ssl-redirect ssl?)
-      wrap-bad-uri
-      wrap-request-logging
-      wrap-keyword-params
-      wrap-json-params
-      wrap-edn-params
-      wrap-nested-params
-      (wrap-multipart-params (make-upload-config))
-      wrap-params
-      (wrap-session {:store (get-cookie-store)})
-      wrap-absolute-redirects
-      (wrap-resource "public")
-      wrap-content-type
-      (wrap-default-charset "utf-8")
-      wrap-not-modified
-      (wrap-xss-protection true {:mode :block})
-      (wrap-frame-options :sameorigin)
-      (wrap-content-type-options :nosniff)
-      wrap-response-logging
-      wrap-gzip
-      wrap-exceptions
-      (optional-middleware wrap-reload reload?)))
+  (let [cookie-attrs (get-config ::session-cookie-attrs)
+        hsts?        (boolean (get-config ::hsts?))]
+    (-> routing-handler
+        (optional-middleware wrap-ssl-redirect ssl?)
+        (optional-middleware wrap-hsts hsts?)
+        wrap-bad-uri
+        wrap-request-logging
+        wrap-keyword-params
+        wrap-json-params
+        wrap-edn-params
+        wrap-nested-params
+        (wrap-multipart-params (make-upload-config))
+        wrap-params
+        (wrap-session (cond-> {:store (get-cookie-store)}
+                        cookie-attrs (assoc :cookie-attrs cookie-attrs)))
+        wrap-absolute-redirects
+        (wrap-resource "public")
+        wrap-content-type
+        (wrap-default-charset "utf-8")
+        wrap-not-modified
+        (wrap-xss-protection true {:mode :block})
+        (wrap-frame-options :sameorigin)
+        (wrap-content-type-options :nosniff)
+        wrap-response-logging
+        wrap-gzip
+        wrap-exceptions
+        (optional-middleware wrap-reload reload?))))
 
 (defonce ^:private handler
   (delay (create-handler-stack

--- a/test/triangulum/handler_test.clj
+++ b/test/triangulum/handler_test.clj
@@ -1,0 +1,40 @@
+(ns triangulum.handler-test
+  (:require [clojure.string     :as str]
+            [clojure.test       :refer [deftest is testing]]
+            [triangulum.config  :refer [get-config]]
+            [triangulum.handler :refer [create-handler-stack]]))
+
+(defn- stub-config
+  "get-config stub: returns m's value keyed by the config keyword; unset keys return nil."
+  [m]
+  (fn [& ks] (get m (first ks))))
+
+(defn- run-request
+  "Build the stack under config `m`, send one GET that writes a session, return the ring response."
+  [m]
+  (with-redefs [get-config (stub-config m)]
+    (let [handler (create-handler-stack (fn [_] {:status 200 :session {:a 1}}) false false)]
+      (handler {:request-method :get :uri "/" :scheme :http
+                :server-name "localhost" :server-port 80 :remote-addr "127.0.0.1" :headers {}}))))
+
+(defn- cookie-attrs [resp]
+  (-> (get-in resp [:headers "Set-Cookie"]) first (str/split #";") (->> (map str/trim) set)))
+
+(deftest ^:unit session-cookie-attrs-test
+  (testing "default: cookie is unchanged - HttpOnly (ring default), no Secure"
+    (let [attrs (cookie-attrs (run-request {}))]
+      (is (contains? attrs "HttpOnly"))
+      (is (not (contains? attrs "Secure")))))
+  (testing "configured :session-cookie-attrs flow onto the session cookie"
+    (let [attrs (cookie-attrs (run-request {:triangulum.handler/session-cookie-attrs
+                                            {:secure true :same-site :lax}}))]
+      (is (contains? attrs "Secure"))
+      (is (contains? attrs "SameSite=Lax"))
+      (is (contains? attrs "HttpOnly")))))   ; ring keeps HttpOnly under the merge
+
+(deftest ^:unit hsts-header-test
+  (testing "default: no HSTS header"
+    (is (nil? (get-in (run-request {}) [:headers "Strict-Transport-Security"]))))
+  (testing ":hsts? true sends Strict-Transport-Security"
+    (is (some? (get-in (run-request {:triangulum.handler/hsts? true})
+                       [:headers "Strict-Transport-Security"])))))


### PR DESCRIPTION
## Purpose

This adds two opt-in config keys for HTTPS hardening, both off by default, so existing deployments don't change. Set `:triangulum.handler/session-cookie-attrs` to a map merged onto the session cookie, like `{:secure true :same-site :lax}`, or leave it unset to keep ring's defaults. Set `:triangulum.handler/hsts? true` to send an HSTS header when served over HTTPS.

Only deployments that set these keys get the hardening, so it's backward-compatible. Tests cover both the default and opt-in paths.